### PR TITLE
Fix warnings when compiling against GCC 5.4

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -353,7 +353,7 @@ void OLEDDisplay::drawFastImage(int16_t xMove, int16_t yMove, int16_t width, int
 
 void OLEDDisplay::drawXbm(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const char *xbm) {
   int16_t widthInXbm = (width + 7) / 8;
-  uint8_t data;
+  uint8_t data = 0;
 
   for(int16_t y = 0; y < height; y++) {
     for(int16_t x = 0; x < width; x++ ) {
@@ -387,6 +387,8 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, char* text, u
       break;
     case TEXT_ALIGN_RIGHT:
       xMove -= textWidth;
+      break;
+    case TEXT_ALIGN_LEFT:
       break;
   }
 

--- a/OLEDDisplay.h
+++ b/OLEDDisplay.h
@@ -250,7 +250,7 @@ class OLEDDisplay : public Print {
     virtual void sendCommand(uint8_t com) {};
 
     // Connect to the display
-    virtual bool connect() {};
+    virtual bool connect() {return true;};
 
     // Send all the init commands
     void sendInitCommands();

--- a/OLEDDisplayUi.cpp
+++ b/OLEDDisplayUi.cpp
@@ -272,6 +272,7 @@ void OLEDDisplayUi::drawFrame(){
           y1 = y + 64;
           break;
         case SLIDE_DOWN:
+        default:
           x = 0;
           y = 64 * progress;
           x1 = 0;
@@ -345,6 +346,7 @@ void OLEDDisplayUi::drawIndicator() {
         posOfHighlightFrame = frameToHighlight;
         break;
       case RIGHT_LEFT:
+      default:
         posOfHighlightFrame = this->frameCount - frameToHighlight;
         break;
     }
@@ -379,6 +381,7 @@ void OLEDDisplayUi::drawIndicator() {
           y = 32 - frameStartPos + 2 + 12 * i;
           break;
         case LEFT:
+        default:
           x = 0 - (8 * indicatorFadeProgress);
           y = 32 - frameStartPos + 2 + 12 * i;
           break;


### PR DESCRIPTION
Fix the following warnings, seen when compiling with GCC 5.4:

    CXX OLEDDisplay.o
    ./OLEDDisplay.cpp: In member function 'void OLEDDisplay::drawStringInternal(int16_t, int16_t, char*, uint16_t, uint16_t)':
    ./OLEDDisplay.cpp:381:10: error: enumeration value 'TEXT_ALIGN_LEFT' not handled in switch [-Werror=switch]
       switch (textAlignment) {
	      ^
    ./OLEDDisplay.cpp: In member function 'void OLEDDisplay::drawInternal(int16_t, int16_t, int16_t, int16_t, const char*, uint16_t, uint16_t)':
    ./OLEDDisplay.cpp:722:13: warning: unused variable 'yScreenPos' [-Wunused-variable]
	 int16_t yScreenPos = yMove + yOffset;
		 ^
    ./OLEDDisplay.cpp: In member function 'void OLEDDisplay::drawXbm(int16_t, int16_t, int16_t, int16_t, const char*)':
    ./OLEDDisplay.cpp:361:19: error: 'data' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	     data >>= 1; // Move a bit
		       ^
    CXX OLEDDisplayUi.o
    ./OLEDDisplayUi.cpp: In member function 'void OLEDDisplayUi::drawFrame()':
    ./OLEDDisplayUi.cpp:284:48: error: 'y1' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	    x *= dir; y *= dir; x1 *= dir; y1 *= dir;
						    ^
    ./OLEDDisplayUi.cpp:284:37: error: 'x1' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	    x *= dir; y *= dir; x1 *= dir; y1 *= dir;
					 ^
    ./OLEDDisplayUi.cpp:284:26: error: 'y' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	    x *= dir; y *= dir; x1 *= dir; y1 *= dir;
			      ^
    ./OLEDDisplayUi.cpp:284:16: error: 'x' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	    x *= dir; y *= dir; x1 *= dir; y1 *= dir;
		    ^
    ./OLEDDisplayUi.cpp: In member function 'void OLEDDisplayUi::drawIndicator()':
    ./OLEDDisplayUi.cpp:393:35: error: 'y' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	   this->display->drawFastImage(x, y, 8, 8, image);
				       ^
    ./OLEDDisplayUi.cpp:393:35: error: 'x' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    ./OLEDDisplayUi.cpp:387:7: error: 'posOfHighlightFrame' may be used uninitialized in this function [-Werror=maybe-uninitialized]
	   if (posOfHighlightFrame == i) {
	   ^
    cc1plus: some warnings being treated as errors