### PR TITLE
Support multiple display resolutions

### DIFF
--- a/OLEDDisplay.h
+++ b/OLEDDisplay.h
@@ -109,7 +109,13 @@ enum OLEDDISPLAY_TEXT_ALIGNMENT {
 
 
 class OLEDDisplay : public Print {
+  private:
+    const int _width, _height;
   public:
+    OLEDDisplay(const int width = DISPLAY_WIDTH, const int height = DISPLAY_HEIGHT) : _width(width), _height(height){ };
+    const int width(void) const { return _width; };
+    const int height(void) const { return _height; };
+
     // Initialize the display
     bool init();
 
@@ -150,7 +156,7 @@ class OLEDDisplay : public Print {
     // Draw a lin vertically
     void drawVerticalLine(int16_t x, int16_t y, int16_t length);
 
-    // Draws a rounded progress bar with the outer dimensions given by width and height. Progress is 
+    // Draws a rounded progress bar with the outer dimensions given by width and height. Progress is
     // a unsigned byte value between 0 and 100
     void drawProgressBar(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint8_t progress);
 

--- a/OLEDDisplayUi.cpp
+++ b/OLEDDisplayUi.cpp
@@ -254,28 +254,28 @@ void OLEDDisplayUi::drawFrame(){
        int16_t x, y, x1, y1;
        switch(this->frameAnimationDirection){
         case SLIDE_LEFT:
-          x = -128 * progress;
+          x = -this->display->width() * progress;
           y = 0;
-          x1 = x + 128;
+          x1 = x + this->display->width();
           y1 = 0;
           break;
         case SLIDE_RIGHT:
-          x = 128 * progress;
+          x = this->display->width() * progress;
           y = 0;
-          x1 = x - 128;
+          x1 = x - this->display->width();
           y1 = 0;
           break;
         case SLIDE_UP:
           x = 0;
-          y = -64 * progress;
+          y = -this->display->height() * progress;
           x1 = 0;
-          y1 = y + 64;
+          y1 = y + this->display->height();
           break;
         case SLIDE_DOWN:
           x = 0;
-          y = 64 * progress;
+          y = this->display->height() * progress;
           x1 = 0;
-          y1 = y - 64;
+          y1 = y - this->display->height();
           break;
        }
 
@@ -368,19 +368,19 @@ void OLEDDisplayUi::drawIndicator() {
       switch (this->indicatorPosition){
         case TOP:
           y = 0 - (8 * indicatorFadeProgress);
-          x = 64 - frameStartPos + 12 * i;
+          x = (this->display->width() / 2) - frameStartPos + 12 * i;
           break;
         case BOTTOM:
-          y = 56 + (8 * indicatorFadeProgress);
-          x = 64 - frameStartPos + 12 * i;
+          y = (this->display->height() - 8) + (8 * indicatorFadeProgress);
+          x = (this->display->width() / 2) - frameStartPos + 12 * i;
           break;
         case RIGHT:
-          x = 120 + (8 * indicatorFadeProgress);
-          y = 32 - frameStartPos + 2 + 12 * i;
+          x = (this->display->width() - 8) + (8 * indicatorFadeProgress);
+          y = (this->display->height() / 2) - frameStartPos + 2 + 12 * i;
           break;
         case LEFT:
           x = 0 - (8 * indicatorFadeProgress);
-          y = 32 - frameStartPos + 2 + 12 * i;
+          y = (this->display->height() / 2) - frameStartPos + 2 + 12 * i;
           break;
       }
 

--- a/SSD1306Wire.h
+++ b/SSD1306Wire.h
@@ -38,7 +38,8 @@ class SSD1306Wire : public OLEDDisplay {
       uint8_t             _scl;
 
   public:
-    SSD1306Wire(uint8_t _address, uint8_t _sda, uint8_t _scl) {
+    SSD1306Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, int width = DISPLAY_WIDTH, int height = DISPLAY_HEIGHT)
+    : OLEDDisplay(width, height) {
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
@@ -53,6 +54,7 @@ class SSD1306Wire : public OLEDDisplay {
     }
 
     void display(void) {
+      const int x_offset = (128 - this->width()) / 2;
       #ifdef OLEDDISPLAY_DOUBLE_BUFFER
         uint8_t minBoundY = ~0;
         uint8_t maxBoundY = 0;
@@ -63,9 +65,9 @@ class SSD1306Wire : public OLEDDisplay {
 
         // Calculate the Y bounding box of changes
         // and copy buffer[pos] to buffer_back[pos];
-        for (y = 0; y < (DISPLAY_HEIGHT / 8); y++) {
-          for (x = 0; x < DISPLAY_WIDTH; x++) {
-           uint16_t pos = x + y * DISPLAY_WIDTH;
+        for (y = 0; y < (this->height() / 8); y++) {
+          for (x = 0; x < this->width(); x++) {
+           uint16_t pos = x + y * this->width();
            if (buffer[pos] != buffer_back[pos]) {
              minBoundY = _min(minBoundY, y);
              maxBoundY = _max(maxBoundY, y);
@@ -83,8 +85,8 @@ class SSD1306Wire : public OLEDDisplay {
         if (minBoundY == ~0) return;
 
         sendCommand(COLUMNADDR);
-        sendCommand(minBoundX);
-        sendCommand(maxBoundX);
+        sendCommand(x_offset + minBoundX);
+        sendCommand(x_offset + maxBoundX);
 
         sendCommand(PAGEADDR);
         sendCommand(minBoundY);
@@ -97,7 +99,7 @@ class SSD1306Wire : public OLEDDisplay {
               Wire.beginTransmission(_address);
               Wire.write(0x40);
             }
-            Wire.write(buffer[x + y * DISPLAY_WIDTH]);
+            Wire.write(buffer[x + y * this->width()]);
             k++;
             if (k == 16)  {
               Wire.endTransmission();
@@ -113,12 +115,12 @@ class SSD1306Wire : public OLEDDisplay {
       #else
 
         sendCommand(COLUMNADDR);
-        sendCommand(0x0);
-        sendCommand(0x7F);
+        sendCommand(x_offset);
+        sendCommand(x_offset + (this->width() - 1));
 
         sendCommand(PAGEADDR);
         sendCommand(0x0);
-        sendCommand(0x7);
+        sendCommand((this->height() / 8) - 1);
 
         for (uint16_t i=0; i < DISPLAY_BUFFER_SIZE; i++) {
           Wire.beginTransmission(this->_address);


### PR DESCRIPTION
Here's basic support for displays of different sizes. I only have an I2C 64x48 SSD1306 and 128x64 SSD1306 display to test with and have only implemented it for the Wire backend (tried it with brzo but had issues elsewhere with timing). 

Hopefully it gives a good starting point if someone has other displays to test with as the display/interface-specific code is fairly minimal.