### PR TITLE
Fixed drawProgressBar

### DIFF
--- a/OLEDDisplay.cpp
+++ b/OLEDDisplay.cpp
@@ -340,7 +340,7 @@ void OLEDDisplay::drawProgressBar(uint16_t x, uint16_t y, uint16_t width, uint16
   drawHorizontalLine(xRadius, y + height, width - doubleRadius + 1);
   drawCircleQuads(x + width - radius, yRadius, radius, 0b00001001);
 
-  uint16_t maxProgressWidth = (width - doubleRadius - 1) * progress / 100;
+  uint16_t maxProgressWidth = (width - doubleRadius + 1) * progress / 100;
 
   fillCircle(xRadius, yRadius, innerRadius);
   fillRect(xRadius + 1, y + 2, maxProgressWidth, height - 3);


### PR DESCRIPTION
Changed negative to positive sign at maxProgressWidth. It fixes the bar progress displayed at 100% value from this:

![photo_2018-02-27_21-50-19](https://user-images.githubusercontent.com/4382333/36754106-6acb45a8-1c08-11e8-9ca6-1a465edd75dc.jpg)

to This:

![photo_2018-02-27_21-50-14](https://user-images.githubusercontent.com/4382333/36754124-732ecc60-1c08-11e8-886f-1d2886fe923a.jpg)

