### PR TITLE
Corrected Circle drawing algorithm

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -159,9 +159,9 @@ void OLEDDisplay::drawCircle(int16_t x0, int16_t y0, int16_t radius) {
 	int16_t dp = 1 - radius;
 	do {
 		if (dp < 0)
-			dp = dp + 2 * (++x) + 3;
+			dp = dp + 2 * (x++) + 3;
 		else
-			dp = dp + 2 * (++x) - 2 * (--y) + 5;
+			dp = dp + 2 * (x++) - 2 * (y--) + 5;
 
 		setPixel(x0 + x, y0 + y);     //For the 8 octants
 		setPixel(x0 - x, y0 + y);
@@ -185,9 +185,9 @@ void OLEDDisplay::drawCircleQuads(int16_t x0, int16_t y0, int16_t radius, uint8_
   int16_t dp = 1 - radius;
   while (x < y) {
     if (dp < 0)
-      dp = dp + 2 * (++x) + 3;
+      dp = dp + 2 * (x++) + 3;
     else
-      dp = dp + 2 * (++x) - 2 * (--y) + 5;
+      dp = dp + 2 * (x++) - 2 * (y--) + 5;
     if (quads & 0x1) {
       setPixel(x0 + x, y0 - y);
       setPixel(x0 + y, y0 - x);
@@ -225,9 +225,9 @@ void OLEDDisplay::fillCircle(int16_t x0, int16_t y0, int16_t radius) {
 	int16_t dp = 1 - radius;
 	do {
 		if (dp < 0)
-			dp = dp + 2 * (++x) + 3;
+			dp = dp + 2 * (x++) + 3;
 		else
-			dp = dp + 2 * (++x) - 2 * (--y) + 5;
+			dp = dp + 2 * (x++) - 2 * (y--) + 5;
 
     drawHorizontalLine(x0 - x, y0 - y, 2*x);
     drawHorizontalLine(x0 - x, y0 + y, 2*x);


### PR DESCRIPTION
I was using this library on on a NodeMCU 1.0 with the vsCode PlatformIO development environment and I noticed that when I ran the basic example code, the circles were squashed (somewhat more like rounded rectangles than circles).  After a few hours of work comparing it to the Adafruit GFX library code and the wikipedia code for the midpoint circle algorithm, I determined that the pre-increments and pre-decrements used in all three circle drawing functions (drawCircle, drawCircleQuads, and fillCircle) should be post-increments and post-decrements.  This commit changes the two ++x's and one --y to x++ and y-- respectively in all three funtions.

I've also verified this correction works properly and fixes the same issue when tested in the Arduino IDE.

With this change, this library now draws circles that match pixel by pixel with the calculations used in the Adafruit GFX library.  My testing has only covered smaller circles as is used in the example code but I believe it should scale up properly.