### PR TITLE
Add support for resuming from deep sleep

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -34,32 +34,41 @@ OLEDDisplay::~OLEDDisplay() {
   end();
 }
 
-bool OLEDDisplay::init() {
+bool OLEDDisplay::resume() {
   if (!this->connect()) {
     DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Can't establish connection to display\n");
     return false;
   }
 
   if(this->buffer==NULL) {
-  this->buffer = (uint8_t*) malloc(sizeof(uint8_t) * displayBufferSize);
+    this->buffer = (uint8_t*) malloc(sizeof(uint8_t) * displayBufferSize);
 
-  if(!this->buffer) {
-    DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Not enough memory to create display\n");
-    return false;
-  }
+    if(!this->buffer) {
+      DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Not enough memory to create display\n");
+      return false;
+    }
   }
 
   #ifdef OLEDDISPLAY_DOUBLE_BUFFER
   if(this->buffer_back==NULL) {
-  this->buffer_back = (uint8_t*) malloc(sizeof(uint8_t) * displayBufferSize);
+    this->buffer_back = (uint8_t*) malloc(sizeof(uint8_t) * displayBufferSize);
 
-  if(!this->buffer_back) {
-    DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Not enough memory to create back buffer\n");
-    free(this->buffer);
-    return false;
-  }
+    if(!this->buffer_back) {
+      DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Not enough memory to create back buffer\n");
+      free(this->buffer);
+      return false;
+    }
   }
   #endif
+
+  return true;
+}
+
+bool OLEDDisplay::init() {
+
+  if(!resume()) {
+    return false;
+  }
 
   sendInitCommands();
   resetDisplay();

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -121,7 +121,10 @@ class OLEDDisplay : public Print {
     const uint16_t width(void) const { return displayWidth; };
     const uint16_t height(void) const { return displayHeight; };
 
-    // Initialize the display
+    // Prepare internal structures for resuming display usage after a deep sleep.
+    bool resume();
+
+    // Initialize the display. Also initializes the library first.
     bool init();
 
     // Free the memory used by the display


### PR DESCRIPTION
In my application I'm leaving the OLED display on while the ESP goes into deep sleep. Currently the init() method resets the whole display, which is not necessary in my case as it will still have its state from before. This results in a flicker whenever the display needs to be written to after a deep sleep.
This adds a `resume()` method which initialises the `OLEDDisplay` object without resetting the actual display, eliminating the flickering.