### PR TITLE
Added 128x32 support documentation and example. Cleaned up SimpleDemo comments. -RXP

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The library supports different protocols to access the OLED display. Currently t
 // for 128x64 displays:
 SSD1306Wire display(0x3c, SDA, SCL);  // ADDRESS, SDA, SCL
 // for 128x32 displays:
-// SSD1306Wire display(0x3c, SDA, SCL, GEOMETRY_128_32);  // ADDRESS, SDA, SCL, OLEDDISPLAY_GEOMETRY (128x32 or 128x64)
+// SSD1306Wire display(0x3c, SDA, SCL, GEOMETRY_128_32);  // ADDRESS, SDA, SCL, GEOMETRY_128_32 (or 128_64)
 ```
 
 for a SH1106:

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 > We just released version 4.0.0. Please have a look at our [upgrade guide](UPGRADE-4.0.md)
 
-This is a driver for the SSD1306 based 128x64 pixel OLED display running on the Arduino/ESP8266 platform.
-Can be used with either the I2C or SPI version of the display
+This is a driver for SSD1306 128x64 and 128x32 OLED displays running on the Arduino/ESP8266 platform.
+Can be used with either the I2C or SPI version of the display.
 
-You can either download this library as a zip file and unpack it to your Arduino/libraries folder or (once it has been added) choose it from the Arduino library manager.
+You can either download this library as a zip file and unpack it to your Arduino/libraries folder or find it in the Arduino library manager under "ESP8266 and ESP32 Oled Driver for SSD1306 display".  
 
 It is also available as a platformio library. Just execute the following command:
 ```
@@ -68,14 +68,18 @@ The library supports different protocols to access the OLED display. Currently t
 #include <Wire.h>  
 #include "SSD1306Wire.h"
 
-SSD1306Wire display(ADDRESS, SDA, SDC);
+// for 128x64 displays:
+SSD1306Wire display(0x3c, SDA, SCL);  // ADDRESS, SDA, SCL
+// for 128x32 displays:
+// SSD1306Wire display(0x3c, SDA, SCL, GEOMETRY_128_32);  // ADDRESS, SDA, SCL, OLEDDISPLAY_GEOMETRY (128x32 or 128x64)
 ```
-or for a SH1106:
+
+for a SH1106:
 ```C++
 #include <Wire.h>  
 #include "SH1106Wire.h"
 
-SH1106Wire display(ADDRESS, SDA, SDC);
+SH1106Wire display(0x3c, SDA, SCL);  // ADDRESS, SDA, SCL
 ```
 
 ### I2C with brzo_i2c
@@ -84,14 +88,14 @@ SH1106Wire display(ADDRESS, SDA, SDC);
 #include <brzo_i2c.h>
 #include "SSD1306Brzo.h"
 
-SSD1306Brzo display(ADDRESS, SDA, SDC);
+SSD1306Brzo display(0x3c, SDA, SCL);  // ADDRESS, SDA, SCL
 ```
 or for the SH1106:
 ```C++
 #include <brzo_i2c.h>
 #include "SH1106Brzo.h"
 
-SH1106Brzo display(ADDRESS, SDA, SDC);
+SH1106Brzo display(0x3c, SDA, SCL);  // ADDRESS, SDA, SCL
 ```
 
 ### SPI
@@ -100,14 +104,14 @@ SH1106Brzo display(ADDRESS, SDA, SDC);
 #include <SPI.h>
 #include "SSD1306Spi.h"
 
-SSD1306Spi display(RES, DC, CS);
+SSD1306Spi display(D0, D2, D8);  // RES, DC, CS
 ```
 or for the SH1106:
 ```C++
 #include <SPI.h>
 #include "SH1106Spi.h"
 
-SH1106Spi display(RES, DC, CS);
+SH1106Spi display(D0, D2);  // RES, DC
 ```
 
 ## API

--- a/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
+++ b/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
@@ -28,29 +28,32 @@
  *
  */
 
+ 
 // Include the correct display library
 
 // For a connection via I2C using the Arduino Wire include:
-#include <Wire.h>  				// Only needed for Arduino 1.6.5 and earlier
-#include "SSD1306Wire.h" 		// legacy: #include "SSD1306.h"
-// OR #include "SH1106Wire.h" 	// legacy: #include "SH1106.h"
+#include <Wire.h>               // Only needed for Arduino 1.6.5 and earlier
+#include "SSD1306Wire.h"        // legacy: #include "SSD1306.h"
+// OR #include "SH1106Wire.h"   // legacy: #include "SH1106.h"
 
 // For a connection via I2C using brzo_i2c (must be installed) include:
-// #include <brzo_i2c.h> 		// Only needed for Arduino 1.6.5 and earlier
+// #include <brzo_i2c.h>        // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Brzo.h"
 // OR #include "SH1106Brzo.h"
 
 // For a connection via SPI include:
-// #include <SPI.h> 			// Only needed for Arduino 1.6.5 and earlier
+// #include <SPI.h>             // Only needed for Arduino 1.6.5 and earlier
 // #include "SSD1306Spi.h"
 // OR #include "SH1106SPi.h"
+
 
 // Optionally include custom images
 #include "images.h"
 
+
 // Initialize the OLED display using Arduino Wire:
 SSD1306Wire display(0x3c, D3, D5);
-// SSD1306Wire display(0x3c, D3, D5, GEOMETRY_128_32);  //optional OLEDDISPLAY_GEOMETRY param required for SSD1306 128x32
+// SSD1306Wire display(0x3c, D3, D5, GEOMETRY_128_32);  //optional OLEDDISPLAY_GEOMETRY param required for 128x32
 // SH1106 display(0x3c, D3, D5);
 
 // Initialize the OLED display using SPI:

--- a/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
+++ b/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
@@ -27,7 +27,6 @@
  * https://thingpulse.com
  *
  */
-
  
 // Include the correct display library
 

--- a/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
+++ b/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
@@ -29,42 +29,44 @@
  */
 
 // Include the correct display library
-// For a connection via I2C using Wire include
-#include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
-#include "SSD1306Wire.h" // legacy include: `#include "SSD1306.h"`
-// or #include "SH1106Wire.h", legacy include: `#include "SH1106.h"`
-// For a connection via I2C using brzo_i2c (must be installed) include
-// #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
-// #include "SSD1306Brzo.h"
-// #include "SH1106Brzo.h"
-// For a connection via SPI include
-// #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
-// #include "SSD1306Spi.h"
-// #include "SH1106SPi.h"
 
-// Include custom images
+// For a connection via I2C using the Arduino Wire include:
+#include <Wire.h>  				// Only needed for Arduino 1.6.5 and earlier
+#include "SSD1306Wire.h" 		// legacy: #include "SSD1306.h"
+// OR #include "SH1106Wire.h" 	// legacy: #include "SH1106.h"
+
+// For a connection via I2C using brzo_i2c (must be installed) include:
+// #include <brzo_i2c.h> 		// Only needed for Arduino 1.6.5 and earlier
+// #include "SSD1306Brzo.h"
+// OR #include "SH1106Brzo.h"
+
+// For a connection via SPI include:
+// #include <SPI.h> 			// Only needed for Arduino 1.6.5 and earlier
+// #include "SSD1306Spi.h"
+// OR #include "SH1106SPi.h"
+
+// Optionally include custom images
 #include "images.h"
 
-// Initialize the OLED display using SPI
+// Initialize the OLED display using Arduino Wire:
+SSD1306Wire display(0x3c, D3, D5);
+// SSD1306Wire display(0x3c, D3, D5, GEOMETRY_128_32);  //optional OLEDDISPLAY_GEOMETRY param required for SSD1306 128x32
+// SH1106 display(0x3c, D3, D5);
+
+// Initialize the OLED display using SPI:
 // D5 -> CLK
 // D7 -> MOSI (DOUT)
 // D0 -> RES
 // D2 -> DC
 // D8 -> CS
-// SSD1306Spi        display(D0, D2, D8);
+// SSD1306Spi display(D0, D2, D8); 	// RES, DC, CS
 // or
-// SH1106Spi         display(D0, D2);
+// SH1106Spi display(D0, D2); 		// RES, DC
 
-// Initialize the OLED display using brzo_i2c
-// D3 -> SDA
-// D5 -> SCL
-// SSD1306Brzo display(0x3c, D3, D5);
+// Initialize the OLED display using brzo_i2c:
+// SSD1306Brzo display(0x3c, D3, D5); 	// ADDRESS, SDA, SCL
 // or
-// SH1106Brzo  display(0x3c, D3, D5);
-
-// Initialize the OLED display using Wire library
-SSD1306Wire  display(0x3c, D3, D5);
-// SH1106 display(0x3c, D3, D5);
+// SH1106Brzo display(0x3c, D3, D5); 	// ADDRESS, SDA, SCL
 
 
 #define DEMO_DURATION 3000

--- a/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
+++ b/examples/SSD1306SimpleDemo/SSD1306SimpleDemo.ino
@@ -51,9 +51,15 @@
 
 
 // Initialize the OLED display using Arduino Wire:
-SSD1306Wire display(0x3c, D3, D5);
-// SSD1306Wire display(0x3c, D3, D5, GEOMETRY_128_32);  //optional OLEDDISPLAY_GEOMETRY param required for 128x32
-// SH1106 display(0x3c, D3, D5);
+SSD1306Wire display(0x3c, SDA, SCL);   // ADDRESS, SDA, SCL  -  SDA and SCL usually populate automatically based on your board's pins_arduino.h
+// SSD1306Wire display(0x3c, D3, D5);  // ADDRESS, SDA, SCL  -  If not, they can be specified manually.
+// SSD1306Wire display(0x3c, SDA, SCL, GEOMETRY_128_32);  // ADDRESS, SDA, SCL, OLEDDISPLAY_GEOMETRY  -  Extra param required for 128x32 displays.
+// SH1106 display(0x3c, SDA, SCL);     // ADDRESS, SDA, SCL
+
+// Initialize the OLED display using brzo_i2c:
+// SSD1306Brzo display(0x3c, D3, D5);  // ADDRESS, SDA, SCL
+// or
+// SH1106Brzo display(0x3c, D3, D5);   // ADDRESS, SDA, SCL
 
 // Initialize the OLED display using SPI:
 // D5 -> CLK
@@ -61,14 +67,9 @@ SSD1306Wire display(0x3c, D3, D5);
 // D0 -> RES
 // D2 -> DC
 // D8 -> CS
-// SSD1306Spi display(D0, D2, D8); 	// RES, DC, CS
+// SSD1306Spi display(D0, D2, D8);  // RES, DC, CS
 // or
-// SH1106Spi display(D0, D2); 		// RES, DC
-
-// Initialize the OLED display using brzo_i2c:
-// SSD1306Brzo display(0x3c, D3, D5); 	// ADDRESS, SDA, SCL
-// or
-// SH1106Brzo display(0x3c, D3, D5); 	// ADDRESS, SDA, SCL
+// SH1106Spi display(D0, D2);       // RES, DC
 
 
 #define DEMO_DURATION 3000


### PR DESCRIPTION
Added 128x32 support to main README documentation and the SimpleDemo example.

Cleaned up SimpleDemo comments for better clarity, added 128x32 init example. (Will test other examples later for 128x32 support.)

Added some clarity to main README instantiation examples, and synced up with SimpleDemo examples.  CS was removed from the SH1106Spi README example as the corresponding SimpleDemo example did not include it. (Please correct both if this is in error.)

Repo description (below title) should also be manually updated on GitHub to reflect 128x32 support. Thanks!

-RXP