### PR TITLE
#147 add wire clock as constructor arg for ssd1306 and sh1106

### DIFF
--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -45,21 +45,23 @@ class SH1106Wire : public OLEDDisplay {
       uint8_t             _address;
       uint8_t             _sda;
       uint8_t             _scl;
+      uint32_t            _wire_clock;
 
   public:
-    SH1106Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
+    SH1106Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, uint32_t _wire_clock = 700000) {
       setGeometry(g);
 
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
+      this->_wire_clock =_wire_clock;
     }
 
     bool connect() {
       Wire.begin(this->_sda, this->_scl);
       // Let's use ~700khz if ESP8266 is in 160Mhz mode
       // this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
-      Wire.setClock(700000);
+      Wire.setClock(this->_wire_clock);
       return true;
     }
 

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -39,22 +39,24 @@ class SSD1306Wire : public OLEDDisplay {
       uint8_t             _address;
       uint8_t             _sda;
       uint8_t             _scl;
+      uint32_t            _wire_clock;
       bool                _doI2cAutoInit = false;
 
   public:
-    SSD1306Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
+    SSD1306Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64, uint32_t _wire_clock = 700000) {
       setGeometry(g);
 
       this->_address = _address;
       this->_sda = _sda;
       this->_scl = _scl;
+      this->_wire_clock = _wire_clock;
     }
 
     bool connect() {
       Wire.begin(this->_sda, this->_scl);
       // Let's use ~700khz if ESP8266 is in 160Mhz mode
-      // this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
-      Wire.setClock(700000);
+      // this will be limited to ~400khz if the ESP8266 in 80Mhz mode.      
+      Wire.setClock(this->_wire_clock);
       return true;
     }
 


### PR DESCRIPTION
I had the problem that on my odroid go (ESP32) the display was messed up while drawing.

I figured out, that i have to set the Wire.setClock from 700000 to 100000 to get the display showing up correctly.

This feature was already requested in issue #147 :)

I left the constructor with the default value of 700000 so it should not have any impact on other users using this library.

To set the clock speed just pass it in the constructor

SSD1306Wire  display(0x3c, D3, D5, GEOMETRY_128_64 ,100000);


