### PR TITLE
Add component.mk file for use in esp-idf build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(COMPONENT_ADD_INCLUDEDIRS src)
+set(COMPONENT_PRIV_REQUIRES arduino-esp32)
+set(COMPONENT_SRCDIRS src)
+register_component()

--- a/component.mk
+++ b/component.mk
@@ -1,0 +1,3 @@
+COMPONENT_ADD_INCLUDEDIRS := src
+COMPONENT_SRCDIRS := src
+CXXFLAGS += -Wno-ignored-qualifiers


### PR DESCRIPTION
This component.mk file allows the esp8266-oled-ssd1306 package to be used as-is as a component in an esp-idf project for the ESP32.

The third line silences the g++ warning about ignored qualifiers. It's optional, and will become unnecessary if a couple of lines in the source code are changed to respect the "const" qualifier.