### PR TITLE
Mbed os support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ void setColor(OLEDDISPLAY_COLOR color);
 // Draw a pixel at given position
 void setPixel(int16_t x, int16_t y);
 
+// Clear a pixel at given position FIXME: INVERSE is untested with this function
+void clearPixel(int16_t x, int16_t y);
+
 // Draw a line from position 0 to position 1
 void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ SH1106Spi display(RES, DC, CS);
 ### Display Control
 
 ```C++
-// Initialize the display
-void init();
+// Initialize the display via init();
+// Optionally the default fonts can be overwritten to save flash memory, e.g. init(ArialMT_Plain_10)
+void init(const uint8_t *defaultFontData);
 
 // Free the memory used by the display
 void end();

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Build Status](https://travis-ci.org/ThingPulse/esp8266-oled-ssd1306.svg?branch=master)](https://travis-ci.org/ThingPulse/esp8266-oled-ssd1306)
 
-# ThingPulse ESP8266 OLED SSD1306
+# ThingPulse OLED SSD1306 (ESP8266/ESP32/Mbed-OS)
 
 > We just released version 4.0.0. Please have a look at our [upgrade guide](UPGRADE-4.0.md)
 
-This is a driver for the SSD1306 based 128x64 pixel OLED display running on the Arduino/ESP8266 platform.
+This is a driver for the SSD1306 based 128x64 pixel OLED display running on the Arduino (ESP8266 and ESP32) and mbed-os platform.
 Can be used with either the I2C or SPI version of the display
 
-You can either download this library as a zip file and unpack it to your Arduino/libraries folder or (once it has been added) choose it from the Arduino library manager.
+You can either download this library as a zip file and unpack it to your Arduino/libraries folder or (once it has been added) choose it from the Arduino library manager. For mbed-os a copy of the files are available as an mbed-os library
 
 It is also available as a platformio library. Just execute the following command:
 ```
@@ -23,6 +23,9 @@ platformio lib install 562
 
 This library has initially been written by Daniel Eichhorn (@squix78). Many thanks go to Fabrice Weinberg (@FWeinb) for optimizing and refactoring many aspects of the library. Also many thanks to the many committers who helped to add new features and who fixed many bugs.
 The init sequence for the SSD1306 was inspired by Adafruit's library for the same display.
+
+## mbed-os
+This library has been adopted to support the ARM mbed-os environment. A copy of this library is available in mbed-os under the name OLED_SSD1306 by Helmut Tschemernjak. An alternate installation option is to copy the following files into your mbed-os project: OLEDDisplay.cpp OLEDDisplay.h OLEDDisplayFonts.h OLEDDisplayUi.cpp OLEDDisplayUi.h SSD1306I2C.h
 
 ## Usage
 

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -954,7 +954,7 @@ void OLEDDisplay::setFontTableLookupFunction(FontTableLookupFunction function) {
 }
 
 
-char DefaultFontTableLookup(const char ch) {
+char DefaultFontTableLookup(const uint8_t ch) {
     // UTF-8 to font table index converter
     // Code form http://playground.arduino.cc/Main/Utf8ascii
 	static uint8_t LASTCHAR;

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -48,6 +48,8 @@ OLEDDisplay::OLEDDisplay() {
 	textAlignment = TEXT_ALIGN_LEFT;
 	fontData = ArialMT_Plain_10;
 	fontTableLookupFunction = DefaultFontTableLookup;
+	buffer = NULL;
+	buffer_back = NULL;
 }
 
 OLEDDisplay::~OLEDDisplay() {

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -427,8 +427,8 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, char* text, u
   uint8_t firstChar        = pgm_read_byte(fontData + FIRST_CHAR_POS);
   uint16_t sizeOfJumpTable = pgm_read_byte(fontData + CHAR_NUM_POS)  * JUMPTABLE_BYTES;
 
-  uint8_t cursorX         = 0;
-  uint8_t cursorY         = 0;
+  uint16_t cursorX         = 0;
+  uint16_t cursorY         = 0;
 
   switch (textAlignment) {
     case TEXT_ALIGN_CENTER_BOTH:

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -49,7 +49,9 @@ OLEDDisplay::OLEDDisplay() {
 	fontData = ArialMT_Plain_10;
 	fontTableLookupFunction = DefaultFontTableLookup;
 	buffer = NULL;
+#ifdef OLEDDISPLAY_DOUBLE_BUFFER
 	buffer_back = NULL;
+#endif
 }
 
 OLEDDisplay::~OLEDDisplay() {

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -133,6 +133,16 @@ void OLEDDisplay::setPixel(int16_t x, int16_t y) {
   }
 }
 
+void OLEDDisplay::clearPixel(int16_t x, int16_t y) {
+	if (x >= 0 && x < this->width() && y >= 0 && y < this->height()) {
+		switch (color) {
+			case BLACK:   buffer[x + (y / 8) * this->width()] |=  (1 << (y & 7)); break;
+			case WHITE:   buffer[x + (y / 8) * this->width()] &= ~(1 << (y & 7)); break;
+			case INVERSE: buffer[x + (y / 8) * this->width()] ^=  (1 << (y & 7)); break;
+		}
+	}
+}
+
 // Bresenham's algorithm - thx wikipedia and Adafruit_GFX
 void OLEDDisplay::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1) {
   int16_t steep = abs(y1 - y0) > abs(x1 - x0);

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -188,9 +188,9 @@ void OLEDDisplay::drawCircle(int16_t x0, int16_t y0, int16_t radius) {
 	int16_t dp = 1 - radius;
 	do {
 		if (dp < 0)
-			dp = dp + 2 * (++x) + 3;
+			dp = dp + 2 * (x++) + 3;
 		else
-			dp = dp + 2 * (++x) - 2 * (--y) + 5;
+			dp = dp + 2 * (x++) - 2 * (y--) + 5;
 
 		setPixel(x0 + x, y0 + y);     //For the 8 octants
 		setPixel(x0 - x, y0 + y);
@@ -214,9 +214,9 @@ void OLEDDisplay::drawCircleQuads(int16_t x0, int16_t y0, int16_t radius, uint8_
   int16_t dp = 1 - radius;
   while (x < y) {
     if (dp < 0)
-      dp = dp + 2 * (++x) + 3;
+      dp = dp + 2 * (x++) + 3;
     else
-      dp = dp + 2 * (++x) - 2 * (--y) + 5;
+      dp = dp + 2 * (x++) - 2 * (y--) + 5;
     if (quads & 0x1) {
       setPixel(x0 + x, y0 - y);
       setPixel(x0 + y, y0 - x);
@@ -254,9 +254,9 @@ void OLEDDisplay::fillCircle(int16_t x0, int16_t y0, int16_t radius) {
 	int16_t dp = 1 - radius;
 	do {
 		if (dp < 0)
-			dp = dp + 2 * (++x) + 3;
+			dp = dp + 2 * (x++) + 3;
 		else
-			dp = dp + 2 * (++x) - 2 * (--y) + 5;
+			dp = dp + 2 * (x++) - 2 * (y--) + 5;
 
     drawHorizontalLine(x0 - x, y0 - y, 2*x);
     drawHorizontalLine(x0 - x, y0 + y, 2*x);

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -45,7 +45,7 @@ OLEDDisplay::OLEDDisplay() {
 	color = WHITE;
 	geometry = GEOMETRY_128_64;
 	textAlignment = TEXT_ALIGN_LEFT;
-	fontData = ArialMT_Plain_10;
+	fontData = NULL;
 	fontTableLookupFunction = DefaultFontTableLookup;
 	buffer = NULL;
 #ifdef OLEDDISPLAY_DOUBLE_BUFFER
@@ -57,8 +57,9 @@ OLEDDisplay::~OLEDDisplay() {
   end();
 }
 
-bool OLEDDisplay::init() {
+bool OLEDDisplay::init(const uint8_t *defaultFontData) {
 
+	fontData = defaultFontData;
 	logBufferSize = 0;
 	logBufferFilled = 0;
 	logBufferLine = 0;

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -42,7 +42,7 @@ OLEDDisplay::OLEDDisplay() {
 
 	displayWidth = 128;
 	displayHeight = 64;
-	displayBufferSize = 1024;
+	displayBufferSize = displayWidth * displayHeight / 8;
 	color = WHITE;
 	geometry = GEOMETRY_128_64;
 	textAlignment = TEXT_ALIGN_LEFT;
@@ -789,19 +789,28 @@ int OLEDDisplay::_putc(int c) {
 #endif
 
 // Private functions
-void OLEDDisplay::setGeometry(OLEDDISPLAY_GEOMETRY g) {
+void OLEDDisplay::setGeometry(OLEDDISPLAY_GEOMETRY g, uint16_t width, uint16_t height) {
   this->geometry = g;
-  if (g == GEOMETRY_128_64) {
-    this->displayWidth                     = 128;
-    this->displayHeight                    = 64;
-  } else if (g == GEOMETRY_128_32) {
-    this->displayWidth                     = 128;
-    this->displayHeight                    = 32;
+  switch (g) {
+  	case GEOMETRY_128_64:
+    	this->displayWidth = 128;
+    	this->displayHeight = 64;
+		break;
+	case GEOMETRY_128_32:
+    	this->displayWidth = 128;
+    	this->displayHeight = 32;
+		break;
+	case GEOMETRY_RAWMODE:
+		this->displayWidth = width > 0 ? width : 128;
+		this->displayHeight = height > 0 ? height : 64;
+		break;
   }
-  this->displayBufferSize                = displayWidth*displayHeight/8;
+  this->displayBufferSize = displayWidth * displayHeight /8;
 }
 
 void OLEDDisplay::sendInitCommands(void) {
+  if (geometry == GEOMETRY_RAWMODE)
+  	return;
   sendCommand(DISPLAYOFF);
   sendCommand(SETDISPLAYCLOCKDIV);
   sendCommand(0xF0); // Increase speed of the display max ~96Hz

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018 by ThingPulse, Daniel Eichhorn
  * Copyright (c) 2018 by Fabrice Weinberg
+ * Copyright (c) 2019 by Helmut Tschemernjak - www.radioshuttle.de
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,20 +29,47 @@
  *
  */
 
+ /*
+  * TODO Helmut
+  * - test/finish dislplay.printf() on mbed-os
+  * - Finish _putc with drawLogBuffer when running display
+  * - Fix problem that the x is larger than 0 (somehow shifted display) on single buffer
+  */
+
 #include "OLEDDisplay.h"
+
+OLEDDisplay::OLEDDisplay() {
+
+	displayWidth = 128;
+	displayHeight = 64;
+	displayBufferSize = 1024;
+	color = WHITE;
+	geometry = GEOMETRY_128_64;
+	textAlignment = TEXT_ALIGN_LEFT;
+	fontData = ArialMT_Plain_10;
+	fontTableLookupFunction = DefaultFontTableLookup;
+}
 
 OLEDDisplay::~OLEDDisplay() {
   end();
 }
 
 bool OLEDDisplay::init() {
+
+	logBufferSize = 0;
+	logBufferFilled = 0;
+	logBufferLine = 0;
+	logBufferMaxLines = 0;
+    logBuffer = NULL;
+	
   if (!this->connect()) {
     DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Can't establish connection to display\n");
     return false;
   }
 
   if(this->buffer==NULL) {
-  this->buffer = (uint8_t*) malloc(sizeof(uint8_t) * displayBufferSize);
+  	this->buffer = (uint8_t*) malloc((sizeof(uint8_t) * displayBufferSize) + getBufferOffset());
+	this->buffer += getBufferOffset();
 
   if(!this->buffer) {
     DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Not enough memory to create display\n");
@@ -51,11 +79,12 @@ bool OLEDDisplay::init() {
 
   #ifdef OLEDDISPLAY_DOUBLE_BUFFER
   if(this->buffer_back==NULL) {
-  this->buffer_back = (uint8_t*) malloc(sizeof(uint8_t) * displayBufferSize);
+  this->buffer_back = (uint8_t*) malloc((sizeof(uint8_t) * displayBufferSize) + getBufferOffset());
+  this->buffer_back += getBufferOffset();
 
   if(!this->buffer_back) {
     DEBUG_OLEDDISPLAY("[OLEDDISPLAY][init] Not enough memory to create back buffer\n");
-    free(this->buffer);
+    free(this->buffer - getBufferOffset());
     return false;
   }
   }
@@ -68,9 +97,9 @@ bool OLEDDisplay::init() {
 }
 
 void OLEDDisplay::end() {
-  if (this->buffer) { free(this->buffer); this->buffer = NULL; }
+  if (this->buffer) { free(this->buffer - getBufferOffset()); this->buffer = NULL; }
   #ifdef OLEDDISPLAY_DOUBLE_BUFFER
-  if (this->buffer_back) { free(this->buffer_back); this->buffer_back = NULL; }
+  if (this->buffer_back) { free(this->buffer_back - getBufferOffset()); this->buffer_back = NULL; }
   #endif
   if (this->logBuffer != NULL) { free(this->logBuffer); this->logBuffer = NULL; }
 }
@@ -419,15 +448,15 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, char* text, u
     int16_t xPos = xMove + cursorX;
     int16_t yPos = yMove + cursorY;
 
-    byte code = text[j];
+    uint8_t code = text[j];
     if (code >= firstChar) {
-      byte charCode = code - firstChar;
+      uint8_t charCode = code - firstChar;
 
       // 4 Bytes per char code
-      byte msbJumpToChar    = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES );                  // MSB  \ JumpAddress
-      byte lsbJumpToChar    = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_LSB);   // LSB /
-      byte charByteSize     = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_SIZE);  // Size
-      byte currentCharWidth = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_WIDTH); // Width
+      uint8_t msbJumpToChar    = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES );                  // MSB  \ JumpAddress
+      uint8_t lsbJumpToChar    = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_LSB);   // LSB /
+      uint8_t charByteSize     = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_SIZE);  // Size
+      uint8_t currentCharWidth = pgm_read_byte( fontData + JUMPTABLE_START + charCode * JUMPTABLE_BYTES + JUMPTABLE_WIDTH); // Width
 
       // Test if the char is drawable
       if (!(msbJumpToChar == 255 && lsbJumpToChar == 255)) {
@@ -734,6 +763,27 @@ size_t OLEDDisplay::write(const char* str) {
   return length;
 }
 
+#ifdef __MBED__
+int OLEDDisplay::_putc(int c) {
+
+	if (!fontData)
+		return 1;
+	if (!logBufferSize) {
+		uint8_t textHeight = pgm_read_byte(fontData + HEIGHT_POS);
+		uint16_t lines =  this->displayHeight / textHeight;
+		uint16_t chars =   2 * (this->displayWidth / textHeight);
+		
+		if (this->displayHeight % textHeight)
+			lines++;
+		if (this->displayWidth % textHeight)
+			chars++;
+		setLogBuffer(lines, chars);
+	}
+
+	return this->write((uint8_t)c);
+}
+#endif
+
 // Private functions
 void OLEDDisplay::setGeometry(OLEDDISPLAY_GEOMETRY g) {
   this->geometry = g;
@@ -810,7 +860,7 @@ void inline OLEDDisplay::drawInternal(int16_t xMove, int16_t yMove, int16_t widt
       yOffset = initYOffset;
     }
 
-    byte currentByte = pgm_read_byte(data + offset + i);
+    uint8_t currentByte = pgm_read_byte(data + offset + i);
 
     int16_t xPos = xMove + (i / rasterHeight);
     int16_t yPos = ((yMove >> 3) + (i % rasterHeight)) * this->width();
@@ -851,8 +901,9 @@ void inline OLEDDisplay::drawInternal(int16_t xMove, int16_t yMove, int16_t widt
         // and setting the new yOffset
         yOffset = 8 - yOffset;
       }
-
+#ifndef __MBED__
       yield();
+#endif
     }
   }
 }
@@ -887,4 +938,27 @@ char* OLEDDisplay::utf8ascii(String str) {
 
 void OLEDDisplay::setFontTableLookupFunction(FontTableLookupFunction function) {
   this->fontTableLookupFunction = function;
+}
+
+
+char DefaultFontTableLookup(const char ch) {
+    // UTF-8 to font table index converter
+    // Code form http://playground.arduino.cc/Main/Utf8ascii
+	static uint8_t LASTCHAR;
+
+	if (ch < 128) { // Standard ASCII-set 0..0x7F handling
+		LASTCHAR = 0;
+		return ch;
+	}
+
+	uint8_t last = LASTCHAR;   // get last char
+	LASTCHAR = ch;
+
+	switch (last) {    // conversion depnding on first UTF8-character
+		case 0xC2: return (uint8_t) ch;
+		case 0xC3: return (uint8_t) (ch | 0xC0);
+		case 0x82: if (ch == 0xAC) return (uint8_t) 0x80;    // special case Euro-symbol
+	}
+
+	return (uint8_t) 0; // otherwise: return zero, if character has to be ignored
 }

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -33,7 +33,6 @@
   * TODO Helmut
   * - test/finish dislplay.printf() on mbed-os
   * - Finish _putc with drawLogBuffer when running display
-  * - Fix problem that the x is larger than 0 (somehow shifted display) on single buffer
   */
 
 #include "OLEDDisplay.h"

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -161,7 +161,7 @@ class OLEDDisplay : public Stream {
 	uint16_t height(void) const { return displayHeight; };
 
     // Initialize the display
-    bool init();
+    bool init(const uint8_t *defaultFontData = ArialMT_Plain_10);
 
     // Free the memory used by the display
     void end();

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -137,7 +137,8 @@ enum OLEDDISPLAY_TEXT_ALIGNMENT {
 
 enum OLEDDISPLAY_GEOMETRY {
   GEOMETRY_128_64   = 0,
-  GEOMETRY_128_32   = 1
+  GEOMETRY_128_32,
+  GEOMETRY_RAWMODE,
 };
 
 typedef char (*FontTableLookupFunction)(const char ch);
@@ -318,7 +319,7 @@ class OLEDDisplay : public Stream {
     uint16_t  displayBufferSize;
 
     // Set the correct height, width and buffer for the geometry
-    void setGeometry(OLEDDISPLAY_GEOMETRY g);
+    void setGeometry(OLEDDISPLAY_GEOMETRY g, uint16_t width = 0, uint16_t height = 0);
 
     OLEDDISPLAY_TEXT_ALIGNMENT   textAlignment;
     OLEDDISPLAY_COLOR            color;

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -141,8 +141,8 @@ enum OLEDDISPLAY_GEOMETRY {
   GEOMETRY_RAWMODE,
 };
 
-typedef char (*FontTableLookupFunction)(const char ch);
-char DefaultFontTableLookup(const char ch);
+typedef char (*FontTableLookupFunction)(const uint8_t ch);
+char DefaultFontTableLookup(const uint8_t ch);
 
 
 #ifdef ARDUINO

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -178,6 +178,9 @@ class OLEDDisplay : public Stream {
 
     // Draw a pixel at given position
     void setPixel(int16_t x, int16_t y);
+	
+	// Clear a pixel at given position FIXME: INVERSE is untested with this function
+	void clearPixel(int16_t x, int16_t y);
 
     // Draw a line from position 0 to position 1
     void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1);

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -303,10 +303,10 @@ class OLEDDisplay : public Stream {
 #endif
 
 
-    uint8_t            *buffer = NULL;
+    uint8_t            *buffer;
 
     #ifdef OLEDDISPLAY_DOUBLE_BUFFER
-    uint8_t            *buffer_back = NULL;
+    uint8_t            *buffer_back;
     #endif
 
   protected:

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -182,9 +182,6 @@ class OLEDDisplay : public Stream {
 	// Clear a pixel at given position FIXME: INVERSE is untested with this function
 	void clearPixel(int16_t x, int16_t y);
 
-    // Clear a pixel at given position FIXME: INVERSE is untested with this function
-    void clearPixel(int16_t x, int16_t y);
-
     // Draw a line from position 0 to position 1
     void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1);
 

--- a/src/OLEDDisplayFonts.h
+++ b/src/OLEDDisplayFonts.h
@@ -1,6 +1,10 @@
 #ifndef OLEDDISPLAYFONTS_h
 #define OLEDDISPLAYFONTS_h
 
+#ifdef __MBED__
+#define PROGMEM
+#endif
+
 const uint8_t ArialMT_Plain_10[] PROGMEM = {
   0x0A, // Width: 10
   0x0D, // Height: 13

--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -61,6 +61,11 @@ OLEDDisplayUi::OLEDDisplayUi(OLEDDisplay *display) {
   state.frameState = FIXED;
   state.currentFrame = 0;
   state.frameTransitionDirection = 1;
+  state.isIndicatorDrawen = true;
+  state.manuelControll = false;
+  state.userData = NULL;
+  shouldDrawIndicators = true;
+  autoTransition = true;
 }
 
 void OLEDDisplayUi::init() {
@@ -235,7 +240,7 @@ int8_t OLEDDisplayUi::update(){
   int8_t timeBudget = this->updateInterval - (frameStart - this->state.lastUpdate);
   if ( timeBudget <= 0) {
     // Implement frame skipping to ensure time budget is keept
-    if (this->autoTransition && this->state.lastUpdate != 0) this->state.ticksSinceLastStateSwitch += ceil(-timeBudget / this->updateInterval);
+    if (this->autoTransition && this->state.lastUpdate != 0) this->state.ticksSinceLastStateSwitch += ceil((double)-timeBudget / (double)this->updateInterval);
 
     this->state.lastUpdate = frameStart;
     this->tick();

--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018 by ThingPulse, Daniel Eichhorn
  * Copyright (c) 2018 by Fabrice Weinberg
+ * Copyright (c) 2019 by Helmut Tschemernjak - www.radioshuttle.de
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,8 +31,36 @@
 
 #include "OLEDDisplayUi.h"
 
+void LoadingDrawDefault(OLEDDisplay *display, LoadingStage* stage, uint8_t progress) {
+      display->setTextAlignment(TEXT_ALIGN_CENTER);
+      display->setFont(ArialMT_Plain_10);
+      display->drawString(64, 18, stage->process);
+      display->drawProgressBar(4, 32, 120, 8, progress);
+};
+
+
 OLEDDisplayUi::OLEDDisplayUi(OLEDDisplay *display) {
   this->display = display;
+	
+  indicatorPosition = BOTTOM;
+  indicatorDirection = LEFT_RIGHT;
+  activeSymbol = ANIMATION_activeSymbol;
+  inactiveSymbol = ANIMATION_inactiveSymbol;
+  frameAnimationDirection   = SLIDE_RIGHT;
+  lastTransitionDirection = 1;
+  ticksPerFrame = 151; // ~ 5000ms at 30 FPS
+  ticksPerTransition = 15;  // ~  500ms at 30 FPS
+  frameCount = 0;
+  nextFrameNumber = -1;
+  overlayCount = 0;
+  indicatorDrawState = 1;
+  loadingDrawFunction = LoadingDrawDefault;
+  updateInterval = 33;
+  state.lastUpdate = 0;
+  state.ticksSinceLastStateSwitch = 0;
+  state.frameState = FIXED;
+  state.currentFrame = 0;
+  state.frameTransitionDirection = 1;
 }
 
 void OLEDDisplayUi::init() {
@@ -194,7 +223,15 @@ OLEDDisplayUiState* OLEDDisplayUi::getUiState(){
 
 
 int8_t OLEDDisplayUi::update(){
+#ifdef ARDUINO
   unsigned long frameStart = millis();
+#elif __MBED__
+	Timer t;
+	t.start();
+	unsigned long frameStart = t.read_ms();
+#else
+#error "Unkown operating system"
+#endif
   int8_t timeBudget = this->updateInterval - (frameStart - this->state.lastUpdate);
   if ( timeBudget <= 0) {
     // Implement frame skipping to ensure time budget is keept
@@ -203,7 +240,13 @@ int8_t OLEDDisplayUi::update(){
     this->state.lastUpdate = frameStart;
     this->tick();
   }
+#ifdef ARDUINO
   return this->updateInterval - (millis() - frameStart);
+#elif __MBED__
+  return this->updateInterval - (t.read_ms() - frameStart);
+#else
+#error "Unkown operating system"
+#endif
 }
 
 
@@ -378,7 +421,7 @@ void OLEDDisplayUi::drawIndicator() {
     uint16_t x = 0,y = 0;
 
 
-    for (byte i = 0; i < this->frameCount; i++) {
+    for (uint8_t i = 0; i < this->frameCount; i++) {
 
       switch (this->indicatorPosition){
         case TOP:

--- a/src/OLEDDisplayUi.h
+++ b/src/OLEDDisplayUi.h
@@ -90,15 +90,15 @@ struct OLEDDisplayUiState {
   FrameState    frameState;
   uint8_t       currentFrame;
 
-  bool          isIndicatorDrawen         = true;
+  bool          isIndicatorDrawen;
 
   // Normal = 1, Inverse = -1;
   int8_t        frameTransitionDirection;
 
-  bool          manuelControll            = false;
+  bool          manuelControll;
 
   // Custom data that can be used by the user
-  void*         userData                  = NULL;
+  void*         userData;
 };
 
 struct LoadingStage {
@@ -121,7 +121,7 @@ class OLEDDisplayUi {
     const uint8_t*         activeSymbol;
     const uint8_t*         inactiveSymbol;
 
-    bool                shouldDrawIndicators      = true;
+    bool                shouldDrawIndicators;
 
     // Values for the Frames
     AnimationDirection  frameAnimationDirection;
@@ -131,7 +131,7 @@ class OLEDDisplayUi {
     uint16_t            ticksPerFrame; 		// ~ 5000ms at 30 FPS
     uint16_t            ticksPerTransition;	// ~  500ms at 30 FPS
 
-    bool                autoTransition            = true;
+    bool                autoTransition;
 
     FrameCallback*      frameFunctions;
     uint8_t             frameCount;

--- a/src/OLEDDisplayUi.h
+++ b/src/OLEDDisplayUi.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2018 by ThingPulse, Daniel Eichhorn
  * Copyright (c) 2018 by Fabrice Weinberg
+ * Copyright (c) 2019 by Helmut Tschemernjak - www.radioshuttle.de
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +32,14 @@
 #ifndef OLEDDISPLAYUI_h
 #define OLEDDISPLAYUI_h
 
+#ifdef ARDUINO
 #include <Arduino.h>
+#elif __MBED__
+#include <mbed.h>
+#else
+#error "Unkown operating system"
+#endif
+
 #include "OLEDDisplay.h"
 
 //#define DEBUG_OLEDDISPLAYUI(...) Serial.printf( __VA_ARGS__ )
@@ -76,16 +84,16 @@ const uint8_t ANIMATION_inactiveSymbol[] PROGMEM = {
 
 // Structure of the UiState
 struct OLEDDisplayUiState {
-  uint64_t     lastUpdate                = 0;
-  uint16_t      ticksSinceLastStateSwitch = 0;
+  uint64_t     lastUpdate;
+  uint16_t      ticksSinceLastStateSwitch;
 
-  FrameState    frameState                = FIXED;
-  uint8_t       currentFrame              = 0;
+  FrameState    frameState;
+  uint8_t       currentFrame;
 
   bool          isIndicatorDrawen         = true;
 
   // Normal = 1, Inverse = -1;
-  int8_t        frameTransitionDirection  = 1;
+  int8_t        frameTransitionDirection;
 
   bool          manuelControll            = false;
 
@@ -107,54 +115,49 @@ class OLEDDisplayUi {
     OLEDDisplay             *display;
 
     // Symbols for the Indicator
-    IndicatorPosition   indicatorPosition         = BOTTOM;
-    IndicatorDirection  indicatorDirection        = LEFT_RIGHT;
+    IndicatorPosition   indicatorPosition;
+    IndicatorDirection  indicatorDirection;
 
-    const uint8_t*         activeSymbol              = ANIMATION_activeSymbol;
-    const uint8_t*         inactiveSymbol            = ANIMATION_inactiveSymbol;
+    const uint8_t*         activeSymbol;
+    const uint8_t*         inactiveSymbol;
 
     bool                shouldDrawIndicators      = true;
 
     // Values for the Frames
-    AnimationDirection  frameAnimationDirection   = SLIDE_RIGHT;
+    AnimationDirection  frameAnimationDirection;
 
-    int8_t              lastTransitionDirection   = 1;
+    int8_t              lastTransitionDirection;
 
-    uint16_t            ticksPerFrame             = 151; // ~ 5000ms at 30 FPS
-    uint16_t            ticksPerTransition        = 15;  // ~  500ms at 30 FPS
+    uint16_t            ticksPerFrame; 		// ~ 5000ms at 30 FPS
+    uint16_t            ticksPerTransition;	// ~  500ms at 30 FPS
 
     bool                autoTransition            = true;
 
     FrameCallback*      frameFunctions;
-    uint8_t             frameCount                = 0;
+    uint8_t             frameCount;
 
     // Internally used to transition to a specific frame
-    int8_t              nextFrameNumber           = -1;
+    int8_t              nextFrameNumber;
 
     // Values for Overlays
     OverlayCallback*    overlayFunctions;
-    uint8_t             overlayCount              = 0;
+    uint8_t             overlayCount;
 
     // Will the Indicator be drawen
     // 3 Not drawn in both frames
     // 2 Drawn this frame but not next
     // 1 Not drown this frame but next
     // 0 Not known yet
-    uint8_t                indicatorDrawState        = 1;
+    uint8_t                indicatorDrawState;
 
     // Loading screen
-    LoadingDrawFunction loadingDrawFunction       = [](OLEDDisplay *display, LoadingStage* stage, uint8_t progress) {
-      display->setTextAlignment(TEXT_ALIGN_CENTER);
-      display->setFont(ArialMT_Plain_10);
-      display->drawString(64, 18, stage->process);
-      display->drawProgressBar(4, 32, 120, 8, progress);
-    };
-
+    LoadingDrawFunction loadingDrawFunction;
+	
     // UI State
     OLEDDisplayUiState      state;
 
     // Bookeeping for update
-    uint8_t             updateInterval            = 33;
+    uint8_t             updateInterval;
 
     uint8_t             getNextFrameNumber();
     void                drawIndicator();

--- a/src/SH1106Brzo.h
+++ b/src/SH1106Brzo.h
@@ -127,6 +127,9 @@ class SH1106Brzo : public OLEDDisplay {
     }
 
   private:
+	int getBufferOffset(void) {
+		return 0;
+	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
       brzo_i2c_start_transaction(_address, BRZO_I2C_SPEED);

--- a/src/SH1106Spi.h
+++ b/src/SH1106Spi.h
@@ -123,6 +123,9 @@ class SH1106Spi : public OLEDDisplay {
     }
 
   private:
+	int getBufferOffset(void) {
+		return 0;
+	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       digitalWrite(_dc, LOW);
       SPI.transfer(com);

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -144,6 +144,9 @@ class SH1106Wire : public OLEDDisplay {
     }
 
   private:
+	int getBufferOffset(void) {
+		return 0;
+	}
     inline void sendCommand(uint8_t command) __attribute__((always_inline)){
       Wire.beginTransmission(_address);
       Wire.write(0x80);

--- a/src/SSD1306Brzo.h
+++ b/src/SSD1306Brzo.h
@@ -148,6 +148,9 @@ class SSD1306Brzo : public OLEDDisplay {
     }
 
   private:
+	int getBufferOffset(void) {
+		return 0;
+	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       uint8_t command[2] = {0x80 /* command mode */, com};
       brzo_i2c_start_transaction(_address, BRZO_I2C_SPEED);

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -135,7 +135,7 @@ private:
 		char _data[2];
 	  	_data[0] = 0x80; // control
 	  	_data[1] = command;
-	  	int ret = _i2c->write(_address, _data, sizeof(_data));
+	  	_i2c->write(_address, _data, sizeof(_data));
     }
 
 	uint8_t             _address;

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -36,6 +36,10 @@
 #include "OLEDDisplay.h"
 #include <mbed.h>
 
+#ifndef UINT8_MAX
+ #define UINT8_MAX 0xff
+#endif
+
 class SSD1306I2C : public OLEDDisplay {
 public:
     SSD1306I2C(uint8_t _address, PinName _sda, PinName _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {

--- a/src/SSD1306I2C.h
+++ b/src/SSD1306I2C.h
@@ -117,7 +117,6 @@ public:
 
         sendCommand(PAGEADDR);
         sendCommand(0x0);							// page start address (0 = reset)
-        sendCommand((this->height() / 8) - 1);		// page end address 7
 
         if (geometry == GEOMETRY_128_64) {
           sendCommand(0x7);

--- a/src/SSD1306Spi.h
+++ b/src/SSD1306Spi.h
@@ -148,6 +148,9 @@ class SSD1306Spi : public OLEDDisplay {
     }
 
   private:
+	int getBufferOffset(void) {
+		return 0;
+	}
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
       digitalWrite(_cs, HIGH);
       digitalWrite(_dc, LOW);

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -128,7 +128,6 @@ class SSD1306Wire : public OLEDDisplay {
 
         sendCommand(PAGEADDR);
         sendCommand(0x0);
-        sendCommand((this->height() / 8) - 1);
 
         if (geometry == GEOMETRY_128_64) {
           sendCommand(0x7);

--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -34,6 +34,11 @@
 #include "OLEDDisplay.h"
 #include <Wire.h>
 
+#ifdef ARDUINO_ARCH_AVR
+#define _min	min
+#define _max	max
+#endif
+
 class SSD1306Wire : public OLEDDisplay {
   private:
       uint8_t             _address;
@@ -51,7 +56,11 @@ class SSD1306Wire : public OLEDDisplay {
     }
 
     bool connect() {
+#ifdef ARDUINO_ARCH_AVR 
+      Wire.begin();
+#else
       Wire.begin(this->_sda, this->_scl);
+#endif
       // Let's use ~700khz if ESP8266 is in 160Mhz mode
       // this will be limited to ~400khz if the ESP8266 in 80Mhz mode.
       Wire.setClock(700000);
@@ -166,7 +175,11 @@ class SSD1306Wire : public OLEDDisplay {
 
     void initI2cIfNeccesary() {
       if (_doI2cAutoInit) {
-        Wire.begin(this->_sda, this->_scl);
+#ifdef ARDUINO_ARCH_AVR 
+      	Wire.begin();
+#else
+      	Wire.begin(this->_sda, this->_scl);
+#endif
       }
     }
 


### PR DESCRIPTION
All changes have been tested to work on Arduino (ESP32) and mbed-os
Added display library support for mbed-os. At preset with SSD1306 with I2C, more displays and SPI will follow later.

Added for mbed a very simple Arduino String emulation which allows to call drawString using UTF8 chars.

Changed the Arduino byte into an uint8_t to be mbed compatible.

Support the mbed-os Stream class (Arduino uses Print)

mbed-os does not support C++11 initialisers in .h class files therefore I initialise variables in the constructor.
    
Changed initialisers functions (fontTableLookupFunction, loadingDrawFunction) to be separate functions to support the mbed-os compiler
    
To use the library for mbed-os copy the following files into your mbed-os project:
    OLEDDisplay.cpp OLEDDisplayFonts.h OLEDDisplayUi.h OLEDDisplay.h
    OLEDDisplayUi.cpp SSD1306I2C.h