### PR TITLE
Add support for resuming from deep sleep

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -57,7 +57,7 @@ OLEDDisplay::~OLEDDisplay() {
   end();
 }
 
-bool OLEDDisplay::init() {
+bool OLEDDisplay::resume() {
 
 	logBufferSize = 0;
 	logBufferFilled = 0;
@@ -92,6 +92,15 @@ bool OLEDDisplay::init() {
   }
   }
   #endif
+
+  return true;
+}
+
+bool OLEDDisplay::init() {
+
+  if(!resume()) {
+    return false;
+  }
 
   sendInitCommands();
   resetDisplay();

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -57,7 +57,7 @@ OLEDDisplay::~OLEDDisplay() {
   end();
 }
 
-bool OLEDDisplay::resume() {
+bool OLEDDisplay::allocateBuffer() {
 
 	logBufferSize = 0;
 	logBufferFilled = 0;
@@ -98,7 +98,7 @@ bool OLEDDisplay::resume() {
 
 bool OLEDDisplay::init() {
 
-  if(!resume()) {
+  if(!allocateBuffer()) {
     return false;
   }
 

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -160,10 +160,12 @@ class OLEDDisplay : public Stream {
 	uint16_t width(void) const { return displayWidth; };
 	uint16_t height(void) const { return displayHeight; };
 
-    // Prepare internal structures for resuming display usage after a deep sleep.
+    // Prepare the driver for resuming display usage after a deep sleep.
+    // Returns true on success. Returns false on failure (no display detected etc).
     bool allocateBuffer();
 
-    // Initialize the display. Also initializes the library first.
+    // Initialize the driver and the display.
+    // Returns true on success. Returns false on failure (no display detected etc).
     bool init();
 
     // Free the memory used by the display

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -161,7 +161,7 @@ class OLEDDisplay : public Stream {
 	uint16_t height(void) const { return displayHeight; };
 
     // Prepare internal structures for resuming display usage after a deep sleep.
-    bool resume();
+    bool allocateBuffer();
 
     // Initialize the display. Also initializes the library first.
     bool init();

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -160,7 +160,10 @@ class OLEDDisplay : public Stream {
 	uint16_t width(void) const { return displayWidth; };
 	uint16_t height(void) const { return displayHeight; };
 
-    // Initialize the display
+    // Prepare internal structures for resuming display usage after a deep sleep.
+    bool resume();
+
+    // Initialize the display. Also initializes the library first.
     bool init();
 
     // Free the memory used by the display


### PR DESCRIPTION
I've updated @ccantill's patch to match the latest head revision. Actual patch content is otherwise identical to ccantil's patch #215 from about a year ago.
Any chance to get this included into master? I'd also like to separate the module's init code from the hardware device's init code, to enable smooth display updates across deep sleeps. It's actually a fairly trivial change... ;-)
