### PR TITLE
fix for build with Arduino Core STM32

### DIFF
--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -34,7 +34,7 @@
 #include "OLEDDisplay.h"
 #include <Wire.h>
 
-#ifdef ARDUINO_ARCH_AVR
+#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_STM32)
 #define _min	min
 #define _max	max
 #endif


### PR DESCRIPTION
[Arduino Core STM32](https://github.com/stm32duino/Arduino_Core_STM32) does not have definitions for _min() and _max().