### PR TITLE
This fixes a display hang if setFrames(...) is called > 35 seconds after boot

### DIFF
--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -236,7 +236,7 @@ int16_t OLEDDisplayUi::update(){
 #else
 #error "Unkown operating system"
 #endif
-  int16_t timeBudget = this->updateInterval - (frameStart - this->state.lastUpdate);
+  int32_t timeBudget = this->updateInterval - (frameStart - this->state.lastUpdate);
   if ( timeBudget <= 0) {
     // Implement frame skipping to ensure time budget is keept
     if (this->autoTransition && this->state.lastUpdate != 0) this->state.ticksSinceLastStateSwitch += ceil((double)-timeBudget / (double)this->updateInterval);


### PR DESCRIPTION
I noticed a funny problem  If you call ui.setFrames(...) and your
device has been running for more than about 33 seconds, the display would
seem to lock-up and stop updating for up to 30ish seconds.  The root cause
was that when state gets reset state.lastUpdate becomes zero and therefore
the math to calculate time budget can be bigger than what can be
represented in a 16 bit int.  If you are unlucky your negative number
will be thought to be a large postive number and the display drawing would
get skipped.

This fixes that by keeping timeBudget as an int32 (which is 'free'
because it probably in a register anyways...)