### PR TITLE
Two displays support for sh1106 displays

### DIFF
--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -45,9 +45,11 @@ class SH1106Wire : public OLEDDisplay {
       uint8_t             _address;
       uint8_t             _sda;
       uint8_t             _scl;
+      bool                _doI2cAutoInit = false;
 
   public:
-    SH1106Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
+    SH1106Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64)
+    {
       setGeometry(g);
 
       this->_address = _address;
@@ -64,6 +66,7 @@ class SH1106Wire : public OLEDDisplay {
     }
 
     void display(void) {
+      initI2cIfNeccesary();
       #ifdef OLEDDISPLAY_DOUBLE_BUFFER
         uint8_t minBoundY = UINT8_MAX;
         uint8_t maxBoundY = 0;
@@ -143,6 +146,10 @@ class SH1106Wire : public OLEDDisplay {
       #endif
     }
 
+    void setI2cAutoInit(bool doI2cAutoInit) {
+      _doI2cAutoInit = doI2cAutoInit;
+    }
+
   private:
 	int getBufferOffset(void) {
 		return 0;
@@ -154,6 +161,17 @@ class SH1106Wire : public OLEDDisplay {
       Wire.endTransmission();
     }
 
+    void initI2cIfNeccesary()
+    {
+      if (_doI2cAutoInit)
+      {
+#ifdef ARDUINO_ARCH_AVR
+        Wire.begin();
+#else
+        Wire.begin(this->_sda, this->_scl);
+#endif
+      }
+    }
 
 };
 

--- a/src/SH1106Wire.h
+++ b/src/SH1106Wire.h
@@ -48,8 +48,7 @@ class SH1106Wire : public OLEDDisplay {
       bool                _doI2cAutoInit = false;
 
   public:
-    SH1106Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64)
-    {
+    SH1106Wire(uint8_t _address, uint8_t _sda, uint8_t _scl, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
       setGeometry(g);
 
       this->_address = _address;
@@ -161,10 +160,8 @@ class SH1106Wire : public OLEDDisplay {
       Wire.endTransmission();
     }
 
-    void initI2cIfNeccesary()
-    {
-      if (_doI2cAutoInit)
-      {
+    void initI2cIfNeccesary() {
+      if (_doI2cAutoInit) {
 #ifdef ARDUINO_ARCH_AVR
         Wire.begin();
 #else


### PR DESCRIPTION
Hey!
I've noticed, that two displays option is supported only by SD1306 displays. I use two sh1106 displats, so I've added this functionality to the sh1106 headers too(using your sd1306 headres as an example)

Maybe, this will be useful for somebody else.

Thanks.
