### PR TITLE
Pass String arguments by reference

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -520,7 +520,7 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, char* text, u
 }
 
 
-void OLEDDisplay::drawString(int16_t xMove, int16_t yMove, String strUser) {
+void OLEDDisplay::drawString(int16_t xMove, int16_t yMove, const String& strUser) {
   uint16_t lineHeight = pgm_read_byte(fontData + HEIGHT_POS);
 
   // char* text must be freed!
@@ -549,7 +549,7 @@ void OLEDDisplay::drawString(int16_t xMove, int16_t yMove, String strUser) {
   free(text);
 }
 
-void OLEDDisplay::drawStringMaxWidth(int16_t xMove, int16_t yMove, uint16_t maxLineWidth, String strUser) {
+void OLEDDisplay::drawStringMaxWidth(int16_t xMove, int16_t yMove, uint16_t maxLineWidth, const String& strUser) {
   uint16_t firstChar  = pgm_read_byte(fontData + FIRST_CHAR_POS);
   uint16_t lineHeight = pgm_read_byte(fontData + HEIGHT_POS);
 
@@ -612,10 +612,9 @@ uint16_t OLEDDisplay::getStringWidth(const char* text, uint16_t length) {
   return max(maxWidth, stringWidth);
 }
 
-uint16_t OLEDDisplay::getStringWidth(String strUser) {
+uint16_t OLEDDisplay::getStringWidth(const String& strUser) {
   char* text = utf8ascii(strUser);
-  uint16_t length = strlen(text);
-  uint16_t width = getStringWidth(text, length);
+  uint16_t width = getStringWidth(text, strlen(text));
   free(text);
   return width;
 }
@@ -967,7 +966,7 @@ void inline OLEDDisplay::drawInternal(int16_t xMove, int16_t yMove, int16_t widt
 }
 
 // You need to free the char!
-char* OLEDDisplay::utf8ascii(String str) {
+char* OLEDDisplay::utf8ascii(const String& str) {
   uint16_t k = 0;
   uint16_t length = str.length() + 1;
 

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -235,19 +235,19 @@ class OLEDDisplay : public Stream {
     /* Text functions */
 
     // Draws a string at the given location
-    void drawString(int16_t x, int16_t y, String text);
+    void drawString(int16_t x, int16_t y, const String& text);
 
     // Draws a String with a maximum width at the given location.
     // If the given String is wider than the specified width
     // The text will be wrapped to the next line at a space or dash
-    void drawStringMaxWidth(int16_t x, int16_t y, uint16_t maxLineWidth, String text);
+    void drawStringMaxWidth(int16_t x, int16_t y, uint16_t maxLineWidth, const String& text);
 
     // Returns the width of the const char* with the current
     // font settings
     uint16_t getStringWidth(const char* text, uint16_t length);
 
     // Convencience method for the const char version
-    uint16_t getStringWidth(String text);
+    uint16_t getStringWidth(const String& text);
 
     // Specifies relative to which anchor point
     // the text is rendered. Available constants:
@@ -353,8 +353,8 @@ class OLEDDisplay : public Stream {
     char      *logBuffer;
 
 
-	// the header size of the buffer used, e.g. for the SPI command header
-	virtual int getBufferOffset(void) = 0;
+    // the header size of the buffer used, e.g. for the SPI command header
+    virtual int getBufferOffset(void) = 0;
 	
     // Send a command to the display (low level function)
     virtual void sendCommand(uint8_t com) {(void)com;};
@@ -366,7 +366,7 @@ class OLEDDisplay : public Stream {
     void sendInitCommands();
 
     // converts utf8 characters to extended ascii
-    char* utf8ascii(String s);
+    char* utf8ascii(const String& s);
 
     void inline drawInternal(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const uint8_t *data, uint16_t offset, uint16_t bytesInData) __attribute__((always_inline));
 


### PR DESCRIPTION
This avoids the copy constructor and is as efficient as move typically.