### PR TITLE
Add support for I2c mux 8 channel - SSD1306

### DIFF
--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -39,6 +39,20 @@
 #define _min	min
 #define _max	max
 #endif
+
+// remove below define if external memory is supported
+#define USE_ONLY_INTERNAL_MEMORY
+
+#ifndef USE_ONLY_INTERNAL_MEMORY
+#define USE_EXTERNAL_MEMORY_FOR_CLASS                            \
+    void * operator new(size_t size)                             \
+    {                                                            \
+        void * p = heap_caps_malloc(size, MALLOC_CAP_SPIRAM);   \
+        return p;                                               \
+    }  
+#else 
+#define USE_EXTERNAL_MEMORY_FOR_CLASS    
+#endif
 //--------------------------------------
 
 class SSD1306Wire : public OLEDDisplay {
@@ -84,6 +98,8 @@ class SSD1306Wire : public OLEDDisplay {
 #endif
       this->_frequency = _frequency;
     }
+
+    USE_EXTERNAL_MEMORY_FOR_CLASS
 
     bool connect() {
 #if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_ARCH8266)


### PR DESCRIPTION
This might be done more generic - but it works well for ssd1306 and does not seem to impact other protocols
so decided to open a PR.

gives the option to support a hardware multiplexer and utilize up to 8 oled screens using only a single i2c address.
simply add in the constructor the mux i2c address and the pin used in the mux for current screen.

Also added an option to use external memory like in some of the esp32 flavours.