### PR TITLE
fixed possible typo in esp8266 arch define (ARDUINO_ARCH_ESP8266)

### DIFF
--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -82,7 +82,7 @@ class SSD1306Wire : public OLEDDisplay {
     }
 
     bool connect() {
-#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_ARCH8266)
+#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_ARCH_ESP8266)
       _wire->begin();
 #else
       // On ESP32 arduino, -1 means 'don't change pins', someone else has called begin for us.
@@ -198,7 +198,7 @@ class SSD1306Wire : public OLEDDisplay {
 
     void initI2cIfNeccesary() {
       if (_doI2cAutoInit) {
-#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_ARCH8266)
+#if !defined(ARDUINO_ARCH_ESP32) && !defined(ARDUINO_ARCH_ESP8266)
       	_wire->begin();
 #else
       	_wire->begin(this->_sda, this->_scl);


### PR DESCRIPTION
noticed this when compiing for Generic ESP8266 module (in arduino IDE 1.8.13).