### PR TITLE
add return values to drawString  & drawStringMaxWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ void drawStringMaxWidth(int16_t x, int16_t y, int16_t maxLineWidth, const String
 
 // Returns the width of the const char* with the current
 // font settings
-uint16_t getStringWidth(const char* text, uint16_t length);
+uint16_t getStringWidth(const char* text, uint16_t length, bool utf8 = false);
 
 // Convencience method for the const char version
 uint16_t getStringWidth(const String &text);

--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ void drawXbm(int16_t x, int16_t y, int16_t width, int16_t height, const uint8_t 
 ## Text operations
 
 ``` C++
-void drawString(int16_t x, int16_t y, const String &text);
+// Draws a string at the given location, returns how many chars have been written
+uint16_t drawString(int16_t x, int16_t y, const String &text);
 
 // Draws a String with a maximum width at the given location.
 // If the given String is wider than the specified width

--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ uint16_t drawString(int16_t x, int16_t y, const String &text);
 // Draws a String with a maximum width at the given location.
 // If the given String is wider than the specified width
 // The text will be wrapped to the next line at a space or dash
-void drawStringMaxWidth(int16_t x, int16_t y, int16_t maxLineWidth, const String &text);
+// returns 0 if everything fits on the screen or the numbers of characters in the
+// first line if not
+uint16_t drawStringMaxWidth(int16_t x, int16_t y, uint16_t maxLineWidth, const String &text);
 
 // Returns the width of the const char* with the current
 // font settings

--- a/examples/SSD1306ScrollVerticalDemo/SSD1306ScrollVerticalDemo.ino
+++ b/examples/SSD1306ScrollVerticalDemo/SSD1306ScrollVerticalDemo.ino
@@ -1,0 +1,91 @@
+/**
+   The MIT License (MIT)
+
+   Copyright (c) 2022 by Stefan Seyfried
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+// Include the correct display library
+// For a connection via I2C using Wire include
+#include <Wire.h>  // Only needed for Arduino 1.6.5 and earlier
+#include "SSD1306Wire.h" // legacy include: `#include "SSD1306.h"`
+// or #include "SH1106Wire.h", legacy include: `#include "SH1106.h"`
+// For a connection via I2C using brzo_i2c (must be installed) include
+// #include <brzo_i2c.h> // Only needed for Arduino 1.6.5 and earlier
+// #include "SSD1306Brzo.h"
+// #include "SH1106Brzo.h"
+// For a connection via SPI include
+// #include <SPI.h> // Only needed for Arduino 1.6.5 and earlier
+// #include "SSD1306Spi.h"
+// #include "SH1106Spi.h"
+
+// Use the corresponding display class:
+
+// Initialize the OLED display using SPI
+// D5 -> CLK
+// D7 -> MOSI (DOUT)
+// D0 -> RES
+// D2 -> DC
+// D8 -> CS
+// SSD1306Spi        display(D0, D2, D8);
+// or
+// SH1106Spi         display(D0, D2);
+
+// Initialize the OLED display using brzo_i2c
+// D3 -> SDA
+// D5 -> SCL
+// SSD1306Brzo display(0x3c, D3, D5);
+// or
+// SH1106Brzo  display(0x3c, D3, D5);
+
+// Initialize the OLED display using Wire library
+SSD1306Wire display(0x3c, SDA, SCL);   // ADDRESS, SDA, SCL  -  SDA and SCL usually populate automatically based on your board's pins_arduino.h e.g. https://github.com/esp8266/Arduino/blob/master/variants/nodemcu/pins_arduino.h
+// SH1106Wire display(0x3c, SDA, SCL);
+
+// UTF-8 sprinkled within, because it tests special conditions in the char-counting code
+const String loremipsum = "Lorem ipsum dolor sit ämet, "
+  "consetetur sadipscing elitr, sed diam nonümy eirmöd "
+  "tempor invidunt ut labore et dolore mägnä aliquyam erat, "
+  "sed diam voluptua. At vero eos et accusam et justo duo "
+  "dolores et ea rebum. Stet clita kasd gubergren, no sea "
+  "takimata sanctus est Lorem ipsum dolor sit amet. "
+  "äöü-ÄÖÜ/ß€é/çØ.";
+
+void setup() {
+  display.init();
+  display.setContrast(255);
+  display.setTextAlignment(TEXT_ALIGN_LEFT);
+  display.setFont(ArialMT_Plain_16);
+  display.display();
+}
+
+void loop() {
+  static uint16_t start_at = 0;
+  display.clear();
+  uint16_t firstline = display.drawStringMaxWidth(0, 0, 128, loremipsum.substring(start_at));
+  display.display();
+  if (firstline != 0) {
+    start_at += firstline;
+  } else {
+    start_at = 0;
+    delay(1000); // additional pause before going back to start
+  }
+  delay(1000);
+}

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -678,7 +678,10 @@ uint16_t OLEDDisplay::drawStringMaxWidth(int16_t xMove, int16_t yMove, uint16_t 
   uint16_t drawStringResult = 1; // later tested for 0 == error, so initialize to 1
 
   for (uint16_t i = 0; i < length; i++) {
-    strWidth += pgm_read_byte(fontData + JUMPTABLE_START + (text[i] - firstChar) * JUMPTABLE_BYTES + JUMPTABLE_WIDTH);
+    char c = (this->fontTableLookupFunction)(text[i]);
+    if (c == 0)
+      continue;
+    strWidth += pgm_read_byte(fontData + JUMPTABLE_START + (c - firstChar) * JUMPTABLE_BYTES + JUMPTABLE_WIDTH);
 
     // Always try to break on a space, dash or slash
     if (text[i] == ' ' || text[i]== '-' || text[i] == '/') {

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -617,14 +617,14 @@ uint16_t OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, const cha
 }
 
 
-void OLEDDisplay::drawString(int16_t xMove, int16_t yMove, const String &strUser) {
+uint16_t OLEDDisplay::drawString(int16_t xMove, int16_t yMove, const String &strUser) {
   uint16_t lineHeight = pgm_read_byte(fontData + HEIGHT_POS);
 
   // char* text must be freed!
   char* text = strdup(strUser.c_str());
   if (!text) {
     DEBUG_OLEDDISPLAY("[OLEDDISPLAY][drawString] Can't allocate char array.\n");
-    return;
+    return 0;
   }
 
   uint16_t yOffset = 0;
@@ -640,14 +640,16 @@ void OLEDDisplay::drawString(int16_t xMove, int16_t yMove, const String &strUser
     yOffset = (lb * lineHeight) / 2;
   }
 
+  uint16_t charDrawn = 0;
   uint16_t line = 0;
   char* textPart = strtok(text,"\n");
   while (textPart != NULL) {
     uint16_t length = strlen(textPart);
-    drawStringInternal(xMove, yMove - yOffset + (line++) * lineHeight, textPart, length, getStringWidth(textPart, length, true), true);
+    charDrawn += drawStringInternal(xMove, yMove - yOffset + (line++) * lineHeight, textPart, length, getStringWidth(textPart, length, true), true);
     textPart = strtok(NULL, "\n");
   }
   free(text);
+  return charDrawn;
 }
 
 void OLEDDisplay::drawStringf( int16_t x, int16_t y, char* buffer, String format, ... )

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -553,13 +553,14 @@ void OLEDDisplay::drawIco16x16(int16_t xMove, int16_t yMove, const uint8_t *ico,
   }
 }
 
-void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8) {
+uint16_t OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8) {
   uint8_t textHeight       = pgm_read_byte(fontData + HEIGHT_POS);
   uint8_t firstChar        = pgm_read_byte(fontData + FIRST_CHAR_POS);
   uint16_t sizeOfJumpTable = pgm_read_byte(fontData + CHAR_NUM_POS)  * JUMPTABLE_BYTES;
 
   uint16_t cursorX         = 0;
   uint16_t cursorY         = 0;
+  uint16_t charCount       = 0;
 
   switch (textAlignment) {
     case TEXT_ALIGN_CENTER_BOTH:
@@ -576,14 +577,15 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, const char* t
   }
 
   // Don't draw anything if it is not on the screen.
-  if (xMove + textWidth  < 0 || xMove > this->width() ) {return;}
-  if (yMove + textHeight < 0 || yMove > this->height()) {return;}
+  if (xMove + textWidth  < 0 || xMove >= this->width() ) {return 0;}
+  if (yMove + textHeight < 0 || yMove >= this->height()) {return 0;}
 
   for (uint16_t j = 0; j < textLength; j++) {
     int16_t xPos = xMove + cursorX;
     int16_t yPos = yMove + cursorY;
     if (xPos > this->width())
       break; // no need to continue
+    charCount++;
 
     uint8_t code;
     if (utf8) {
@@ -611,6 +613,7 @@ void OLEDDisplay::drawStringInternal(int16_t xMove, int16_t yMove, const char* t
       cursorX += currentCharWidth;
     }
   }
+  return charCount;
 }
 
 

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -255,7 +255,7 @@ class OLEDDisplay : public Stream {
 
     // Returns the width of the const char* with the current
     // font settings
-    uint16_t getStringWidth(const char* text, uint16_t length);
+    uint16_t getStringWidth(const char* text, uint16_t length, bool utf8 = false);
 
     // Convencience method for the const char version
     uint16_t getStringWidth(const String &text);
@@ -382,7 +382,7 @@ class OLEDDisplay : public Stream {
 
     void inline drawInternal(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const uint8_t *data, uint16_t offset, uint16_t bytesInData) __attribute__((always_inline));
 
-    void drawStringInternal(int16_t xMove, int16_t yMove, char* text, uint16_t textLength, uint16_t textWidth);
+    void drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8);
 
 	FontTableLookupFunction fontTableLookupFunction;
 };

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -382,7 +382,7 @@ class OLEDDisplay : public Stream {
 
     void inline drawInternal(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const uint8_t *data, uint16_t offset, uint16_t bytesInData) __attribute__((always_inline));
 
-    void drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8);
+    uint16_t drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8);
 
 	FontTableLookupFunction fontTableLookupFunction;
 };

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -251,7 +251,9 @@ class OLEDDisplay : public Stream {
     // Draws a String with a maximum width at the given location.
     // If the given String is wider than the specified width
     // The text will be wrapped to the next line at a space or dash
-    void drawStringMaxWidth(int16_t x, int16_t y, uint16_t maxLineWidth, const String &text);
+    // returns 0 if everything fits on the screen or the numbers of characters in the
+    // first line if not
+    uint16_t drawStringMaxWidth(int16_t x, int16_t y, uint16_t maxLineWidth, const String &text);
 
     // Returns the width of the const char* with the current
     // font settings

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -242,8 +242,8 @@ class OLEDDisplay : public Stream {
 
     /* Text functions */
 
-    // Draws a string at the given location
-    void drawString(int16_t x, int16_t y, const String &text);
+    // Draws a string at the given location, returns how many chars have been written
+    uint16_t drawString(int16_t x, int16_t y, const String &text);
 
     // Draws a formatted string (like printf) at the given location
     void drawStringf(int16_t x, int16_t y, char* buffer, String format, ... );


### PR DESCRIPTION
The idea is, to give the calling code a bit more information about what was drawn.

drawString() will return the number of characters that have been drawn before the display ended, so that the calling code can use this to draw the rest of the string into a new line, or to implement some kind of horizontal scrolling.

drawStringMaxWidth() will return the number of characters drawn in the first line, so that the calling code can start drawing with the second line in the next iteration, to implement a kind of vertical scrolling.

To get the counting of UTF-8 characters right, I removed utf8ascii() and instead convert the strings on the fly while processing. This might save some runtime memory (the copy that holds the decoded string is not needed anymore) and slightly reduce code size, but I have not measured this extensively.

When breaking up lines in drawStringMaxWidth(), trailing and leading spaces in each line are now removed, leading to smoother display, e.g. in TEXT_ALIGN_CENTER mode. This is the only change that might be visible when the other new features (return codes) are not used. Other than that, the code should display identically with unchanged usage.

This is intended as a draft / suggestion for discussion, not necessarily as a finished solution (even though it works well with my test cases ;-))