### PR TITLE
allow SPI display usage without CS pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,10 @@ or for the SH1106:
 #include <SPI.h>
 #include "SH1106Spi.h"
 
-SH1106Spi display(D0, D2);  // RES, DC
+SH1106Spi display(D0, D2, CS);  // RES, DC, CS
 ```
+
+In case the CS pin is not used (hard wired to ground), pass CS as -1.
 
 ## API
 

--- a/src/SH1106Spi.h
+++ b/src/SH1106Spi.h
@@ -41,6 +41,7 @@ class SH1106Spi : public OLEDDisplay {
       uint8_t             _cs;
 
   public:
+    /* pass _cs as -1 to indicate "do not use CS pin", for cases where it is hard wired low */
     SH1106Spi(uint8_t _rst, uint8_t _dc, uint8_t _cs, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
         setGeometry(g);
 
@@ -51,7 +52,8 @@ class SH1106Spi : public OLEDDisplay {
 
     bool connect(){
       pinMode(_dc, OUTPUT);
-      pinMode(_cs, OUTPUT);
+      if (_cs != (uint8_t) -1)
+        pinMode(_cs, OUTPUT);
       pinMode(_rst, OUTPUT);
 
       SPI.begin ();
@@ -105,13 +107,13 @@ class SH1106Spi : public OLEDDisplay {
          sendCommand(0xB0 + y);
          sendCommand(minBoundXp2H);
          sendCommand(minBoundXp2L);
-         digitalWrite(_cs, HIGH);
+         set_CS(HIGH);
          digitalWrite(_dc, HIGH);   // data mode
-         digitalWrite(_cs, LOW);
+         set_CS(LOW);
          for (x = minBoundX; x <= maxBoundX; x++) {
            SPI.transfer(buffer[x + y * displayWidth]);
          }
-         digitalWrite(_cs, HIGH);
+         set_CS(HIGH);
          yield();
        }
      #else
@@ -119,13 +121,13 @@ class SH1106Spi : public OLEDDisplay {
         sendCommand(0xB0 + y);
         sendCommand(0x02);
         sendCommand(0x10);
-        digitalWrite(_cs, HIGH);
+        set_CS(HIGH);
         digitalWrite(_dc, HIGH);   // data mode
-        digitalWrite(_cs, LOW);
+        set_CS(LOW);
         for( uint8_t x=0; x < displayWidth; x++) {
           SPI.transfer(buffer[x + y * displayWidth]);
         }
-        digitalWrite(_cs, HIGH);
+        set_CS(HIGH);
         yield();
       }
      #endif
@@ -135,12 +137,17 @@ class SH1106Spi : public OLEDDisplay {
 	int getBufferOffset(void) {
 		return 0;
 	}
+    inline void set_CS(bool level) {
+      if (_cs != (uint8_t) -1) {
+        digitalWrite(_cs, level);
+      }
+    };
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
-      digitalWrite(_cs, HIGH);
+      set_CS(HIGH);
       digitalWrite(_dc, LOW);
-      digitalWrite(_cs, LOW);
+      set_CS(LOW);
       SPI.transfer(com);
-      digitalWrite(_cs, HIGH);
+      set_CS(HIGH);
     }
 };
 

--- a/src/SH1106Spi.h
+++ b/src/SH1106Spi.h
@@ -52,8 +52,9 @@ class SH1106Spi : public OLEDDisplay {
 
     bool connect(){
       pinMode(_dc, OUTPUT);
-      if (_cs != (uint8_t) -1)
+      if (_cs != (uint8_t) -1) {
         pinMode(_cs, OUTPUT);
+      }  
       pinMode(_rst, OUTPUT);
 
       SPI.begin ();

--- a/src/SSD1306Spi.h
+++ b/src/SSD1306Spi.h
@@ -47,6 +47,7 @@ class SSD1306Spi : public OLEDDisplay {
       uint8_t             _cs;
 
   public:
+    /* pass _cs as -1 to indicate "do not use CS pin", for cases where it is hard wired low */
     SSD1306Spi(uint8_t _rst, uint8_t _dc, uint8_t _cs, OLEDDISPLAY_GEOMETRY g = GEOMETRY_128_64) {
         setGeometry(g);
 
@@ -57,7 +58,8 @@ class SSD1306Spi : public OLEDDisplay {
 
     bool connect(){
       pinMode(_dc, OUTPUT);
-      pinMode(_cs, OUTPUT);
+      if (_cs != (uint8_t) -1)
+        pinMode(_cs, OUTPUT);
       pinMode(_rst, OUTPUT);
 
       SPI.begin ();
@@ -111,16 +113,16 @@ class SSD1306Spi : public OLEDDisplay {
        sendCommand(minBoundY);
        sendCommand(maxBoundY);
 
-       digitalWrite(_cs, HIGH);
+       set_CS(HIGH);
        digitalWrite(_dc, HIGH);   // data mode
-       digitalWrite(_cs, LOW);
+       set_CS(LOW);
        for (y = minBoundY; y <= maxBoundY; y++) {
          for (x = minBoundX; x <= maxBoundX; x++) {
            SPI.transfer(buffer[x + y * displayWidth]);
          }
          yield();
        }
-       digitalWrite(_cs, HIGH);
+       set_CS(HIGH);
      #else
        // No double buffering
        sendCommand(COLUMNADDR);
@@ -136,14 +138,14 @@ class SSD1306Spi : public OLEDDisplay {
          sendCommand(0x3);
        }
 
-        digitalWrite(_cs, HIGH);
+        set_CS(HIGH);
         digitalWrite(_dc, HIGH);   // data mode
-        digitalWrite(_cs, LOW);
+        set_CS(LOW);
         for (uint16_t i=0; i<displayBufferSize; i++) {
           SPI.transfer(buffer[i]);
           yield();
         }
-        digitalWrite(_cs, HIGH);
+        set_CS(HIGH);
      #endif
     }
 
@@ -151,12 +153,17 @@ class SSD1306Spi : public OLEDDisplay {
 	int getBufferOffset(void) {
 		return 0;
 	}
+    inline void set_CS(bool level) {
+      if (_cs != (uint8_t) -1) {
+        digitalWrite(_cs, level);
+      }
+    };
     inline void sendCommand(uint8_t com) __attribute__((always_inline)){
-      digitalWrite(_cs, HIGH);
+      set_CS(HIGH);
       digitalWrite(_dc, LOW);
-      digitalWrite(_cs, LOW);
+      set_CS(LOW);
       SPI.transfer(com);
-      digitalWrite(_cs, HIGH);
+      set_CS(HIGH);
     }
 };
 

--- a/src/SSD1306Spi.h
+++ b/src/SSD1306Spi.h
@@ -58,8 +58,9 @@ class SSD1306Spi : public OLEDDisplay {
 
     bool connect(){
       pinMode(_dc, OUTPUT);
-      if (_cs != (uint8_t) -1)
+      if (_cs != (uint8_t) -1) {
         pinMode(_cs, OUTPUT);
+      }  
       pinMode(_rst, OUTPUT);
 
       SPI.begin ();


### PR DESCRIPTION
If there is only one SPI device, the CS pin can be hardwired to ground. In that case, the CS pin setting should be ignored. Allow for that if CS is passed as "-1".