### PR TITLE
ESP32 improve display speed for SSD1306

### DIFF
--- a/src/SSD1306Wire.h
+++ b/src/SSD1306Wire.h
@@ -39,6 +39,11 @@
 #define _min	min
 #define _max	max
 #endif
+#if defined(ARDUINO_ARCH_ESP32)
+#define I2C_MAX_TRANSFER_BYTE 128 /** ESP32 can Transfer 128 bytes */
+#else
+#define I2C_MAX_TRANSFER_BYTE 17
+#endif
 //--------------------------------------
 
 class SSD1306Wire : public OLEDDisplay {
@@ -147,7 +152,7 @@ class SSD1306Wire : public OLEDDisplay {
 
             _wire->write(buffer[x + y * this->width()]);
             k++;
-            if (k == 16)  {
+            if (k == (I2C_MAX_TRANSFER_BYTE - 1))  {
               _wire->endTransmission();
               k = 0;
             }
@@ -170,7 +175,7 @@ class SSD1306Wire : public OLEDDisplay {
         for (uint16_t i=0; i < displayBufferSize; i++) {
           _wire->beginTransmission(this->_address);
           _wire->write(0x40);
-          for (uint8_t x = 0; x < 16; x++) {
+          for (uint8_t x = 0; x < (I2C_MAX_TRANSFER_BYTE - 1); x++) {
             _wire->write(buffer[i]);
             i++;
           }


### PR DESCRIPTION
This PR is ESP32 improve display speed for SSD1306 .  
ESP32 can I2C Transfer Max 128 bytes .  
But This library Transfer Max 17 bytes .  
So I modded this .  

Tested with I2C SSD1306 OLED 128x64  
ESP32-D0WDQ6 (revision v1.0)  
ESP32-D0WD-V3 (revision v3.0)  
ESP32-S3 (revision v0.1)  
The drawing speed per screen has increased from 15.80ms to 12.02ms, which is 3.78ms(27% UP) faster !  

* Original Transfer 17 bytes (ESP32-D0WDQ6)  
![image](https://user-images.githubusercontent.com/16265606/224525869-81f7cde1-5146-4c25-b300-0bbcc03154a9.png)  
![image](https://user-images.githubusercontent.com/16265606/224525875-475caa14-3ceb-432e-9e72-25fa603df5be.png)  
  
* Modded Transfer 128 bytes (ESP32-D0WDQ6)  
![image](https://user-images.githubusercontent.com/16265606/224525891-cbe631b5-3979-4a7b-81b8-aa2fe57f11ec.png)  
![image](https://user-images.githubusercontent.com/16265606/224525926-baa5ea2b-f437-476c-9ebb-699164724e77.png)  
