### PR TITLE
Added drawLogBuffer(0,0) and display() at end of write()

### DIFF
--- a/examples/SSD1306DrawingDemo/SSD1306DrawingDemo.ino
+++ b/examples/SSD1306DrawingDemo/SSD1306DrawingDemo.ino
@@ -171,10 +171,6 @@ void drawCircle(void) {
 }
 
 void printBuffer(void) {
-  // Initialize the log buffer
-  // allocate memory to store 8 lines of text and 30 chars per line.
-  display.setLogBuffer(5, 30);
-
   // Some test data
   const char* test[] = {
     "Hello",
@@ -189,15 +185,10 @@ void printBuffer(void) {
     "scrolling is",
     "working"
   };
-
+  display.clear();
   for (uint8_t i = 0; i < 11; i++) {
-    display.clear();
     // Print to the screen
     display.println(test[i]);
-    // Draw it to the internal screen buffer
-    display.drawLogBuffer(0, 0);
-    // Display it on the screen
-    display.display();
     delay(500);
   }
 }

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -884,7 +884,7 @@ size_t OLEDDisplay::write(uint8_t c) {
 	if (!logBufferSize) {
 		uint8_t textHeight = pgm_read_byte(fontData + HEIGHT_POS);
 		uint16_t lines =  this->displayHeight / textHeight;
-		uint16_t chars =   2 * (this->displayWidth / textHeight);
+		uint16_t chars =   3 * (this->displayWidth / textHeight);
 
 		if (this->displayHeight % textHeight)
 			lines++;

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -364,6 +364,7 @@ class OLEDDisplay : public Stream {
     uint16_t   logBufferLine;
     uint16_t   logBufferMaxLines;
     char      *logBuffer;
+    bool      inhibitDrawLogBuffer;
 
 
 	// the header size of the buffer used, e.g. for the SPI command header


### PR DESCRIPTION
Now print, println and printf "just work" because they execute drawLogBuffer(0,0) and display() when done.

New protected boolean `inhibitDrawLogBuffer` makes sure display is not refreshed every character when a string of characters is written at once. I think this is the implementation of what was Helmut's TODO item at the beginning of the file, which read: "Finish _putc with drawLogBuffer when running display". Note that I moved the creation of the logbuffer from _putc() to write(), because we also want it it to "just work" on Arduino.