### PR TITLE
Also accept char* pointer for fonts

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -754,6 +754,10 @@ void OLEDDisplay::setFont(const uint8_t *fontData) {
   this->fontData = fontData;
 }
 
+void OLEDDisplay::setFont(const char *fontData) {
+  this->fontData = static_cast<const uint8_t*>(reinterpret_cast<const void*>(fontData));
+}
+
 void OLEDDisplay::displayOn(void) {
   sendCommand(DISPLAYON);
 }

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -755,7 +755,7 @@ void OLEDDisplay::setFont(const uint8_t *fontData) {
 }
 
 void OLEDDisplay::setFont(const char *fontData) {
-  this->fontData = static_cast<const uint8_t*>(reinterpret_cast<const void*>(fontData));
+  setFont(static_cast<const uint8_t*>(reinterpret_cast<const void*>(fontData)));
 }
 
 void OLEDDisplay::displayOn(void) {

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -271,6 +271,9 @@ class OLEDDisplay : public Stream {
     // ArialMT_Plain_10, ArialMT_Plain_16, ArialMT_Plain_24
     void setFont(const uint8_t *fontData);
 
+    // Set the current font when supplied as a char* instead of a uint8_t*
+    void setFont(const char *fontData);
+
     // Set the function that will convert utf-8 to font table index
     void setFontTableLookupFunction(FontTableLookupFunction function);
 


### PR DESCRIPTION
The [squix.ch tool](https://oleddisplay.squix.ch/) mentioned in the README maybe provided a `uint8_t` array at one point, or maybe we switched, but as it is now it provides a char array, so the font files from there don't work. This patch fixes that by converting the pointer we get. 