### PR TITLE
Implemented cls(), documented Print functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,25 @@ void setTextAlignment(OLEDDISPLAY_TEXT_ALIGNMENT textAlignment);
 void setFont(const uint8_t* fontData);
 ```
 
+## Arduino `Print` functionality
+
+Because this class has been "derived" from Arduino's `Print` class, you can use the functions it provides. In plain language, this means that you can use `print`, `println` and `printf` to the display. Internally, a buffer holds the text that was printed to the display previously (that would still fit on the display) and every time you print something, this buffer is put on the screen, using the functions from the previous section.
+
+What that means is that printing using `print` and "manually" putting things on the display are somewhat mutually exclusive: as soon as you print, everything that was on the display already is gone and only what you put there before with `print`, `println` or `printf` remains. Still, using `print` is a very simple way to put something on the display quickly.
+
+One extra function is provided: `cls()`
+```cpp
+// cls() will clear the display immediately and empty the logBuffer, meaning
+// the next print statement will print at the top of the display again.
+// cls() should not be confused with clear(), which only clears the internal
+// graphics buffer, which can then be shown on the display with display().
+void cls();
+```
+
+&nbsp;
+
+<hr>
+
 ## Ui Library (OLEDDisplayUi)
 
 The Ui Library is used to provide a basic set of user interface elements called `Frames` and `Overlays`. A `Frame` is used to provide

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -861,6 +861,13 @@ uint16_t OLEDDisplay::getHeight(void) {
   return displayHeight;
 }
 
+void OLEDDisplay::cls() {
+  clear();
+  this->logBufferFilled = 0;
+  this->logBufferLine = 0;
+  display();
+}
+
 bool OLEDDisplay::setLogBuffer(uint16_t lines, uint16_t chars){
   if (logBuffer != NULL) free(logBuffer);
   uint16_t size = lines * chars;

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -311,14 +311,27 @@ class OLEDDisplay : public Stream {
     // Clear the local pixel buffer
     void clear(void);
 
-    // Log buffer implementation
+    // Print class device
 
-    // This will define the lines and characters you can
-    // print to the screen. When you exeed the buffer size (lines * chars)
-    // the output may be truncated due to the size constraint.
+    // Because this display class is "derived" from Arduino's Print class,
+    // various function that work on it also work here. These functions include
+    // print, println and printf. 
+
+    // cls() will clear the display immediately and empty the logBuffer, meaning
+    // the next print statement will print at the top of the display again.
+    // cls() should not be confused with clear(), which only clears the internal
+    // graphics buffer, which can then be shown on the display with display().
+    void cls();
+
+    // This will define the lines and characters you can print to the screen.
+    // When you exeed the buffer size (lines * chars) the output may be
+    // truncated due to the size constraint. (Automatically called with the
+    // correct parameters when you first print to the display.)
     bool setLogBuffer(uint16_t lines, uint16_t chars);
 
     // Draw the log buffer at position (x, y)
+    //
+    // (Automatically called with you use print, println or printf)
     void drawLogBuffer(uint16_t x, uint16_t y);
 
     // Get screen geometry


### PR DESCRIPTION
There was no previous way for the user to empty the logBuffer, cls() fixes that.

Also the documentation now explains the Print functionality and how it relates to the rest of the functions.