### PR TITLE
More printing fixes

### DIFF
--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -752,6 +752,8 @@ void OLEDDisplay::setTextAlignment(OLEDDISPLAY_TEXT_ALIGNMENT textAlignment) {
 
 void OLEDDisplay::setFont(const uint8_t *fontData) {
   this->fontData = fontData;
+  // New font, so must recalculate. Whatever was there is gone at next print.
+  setLogBuffer();
 }
 
 void OLEDDisplay::displayOn(void) {
@@ -832,7 +834,7 @@ void OLEDDisplay::drawLogBuffer(uint16_t xMove, uint16_t yMove) {
   // If the lineHeight and the display height are not cleanly divisible, we need
   // to start off the screen when the buffer has logBufferMaxLines so that the
   // first line, and not the last line, drops off.
-  uint16_t shiftUp = (this->logBufferLine == this->logBufferMaxLines) ? displayHeight % lineHeight : 0;
+  uint16_t shiftUp = (this->logBufferLine == this->logBufferMaxLines) ? (lineHeight - (displayHeight % lineHeight)) % lineHeight : 0;
 
   for (uint16_t i=0;i<this->logBufferFilled;i++){
     length++;
@@ -868,21 +870,39 @@ void OLEDDisplay::cls() {
   display();
 }
 
-bool OLEDDisplay::setLogBuffer(uint16_t lines, uint16_t chars){
-  if (logBuffer != NULL) free(logBuffer);
+bool OLEDDisplay::setLogBuffer(){
+  // don't know how big we need it without a font set.
+  if (!fontData)
+		return false;
+  
+  // we're always starting over
+  if (logBuffer != NULL)
+    free(logBuffer);
+
+  // figure out how big it needs to be
+  uint8_t textHeight = pgm_read_byte(fontData + HEIGHT_POS);
+  if (!textHeight)
+    return false;  // Prevent division by zero crashes
+  uint16_t lines =  this->displayHeight / textHeight + (this->displayHeight % textHeight ? 1 : 0);
+  uint16_t chars =   5 * (this->displayWidth / textHeight);
   uint16_t size = lines * (chars + 1);  // +1 is for \n
-  if (size > 0) {
-    this->logBufferLine     = 0;      // Lines printed
-    this->logBufferFilled   = 0;      // Nothing stored yet
-    this->logBufferMaxLines = lines;  // Lines max printable
-    this->logBufferLineLen  = chars;  // Chars per line
-    this->logBufferSize     = size;   // Total number of characters the buffer can hold
-    this->logBuffer         = (char *) malloc(size * sizeof(uint8_t));
-    if(!this->logBuffer) {
-      DEBUG_OLEDDISPLAY("[OLEDDISPLAY][setLogBuffer] Not enough memory to create log buffer\n");
-      return false;
-    }
+
+  // Something weird must have happened
+  if (size == 0) 
+    return false;
+
+  // All good, initialize logBuffer
+  this->logBufferLine     = 0;      // Lines printed
+  this->logBufferFilled   = 0;      // Nothing stored yet
+  this->logBufferMaxLines = lines;  // Lines max printable
+  this->logBufferLineLen  = chars;  // Chars per line
+  this->logBufferSize     = size;   // Total number of characters the buffer can hold
+  this->logBuffer         = (char *) malloc(size * sizeof(uint8_t));
+  if(!this->logBuffer) {
+    DEBUG_OLEDDISPLAY("[OLEDDISPLAY][setLogBuffer] Not enough memory to create log buffer\n");
+    return false;
   }
+
   return true;
 }
 
@@ -892,13 +912,9 @@ size_t OLEDDisplay::write(uint8_t c) {
     
   // Create a logBuffer if there isn't one
 	if (!logBufferSize) {
-		uint8_t textHeight = pgm_read_byte(fontData + HEIGHT_POS);
-		uint16_t lines =  this->displayHeight / textHeight;
-		uint16_t chars =   5 * (this->displayWidth / textHeight);
-
-		if (this->displayHeight % textHeight)
-			lines++;
-		setLogBuffer(lines, chars);
+    // Give up if we can't create a logBuffer somehow
+		if (!setLogBuffer())
+      return 1;
 	}
 
   // Don't waste space on \r\n line endings, dropping \r
@@ -961,7 +977,7 @@ size_t OLEDDisplay::write(uint8_t c) {
     display();
   }
 
-  // We are always claim we printed it all
+  // We always claim we printed it all
   return 1;
 }
 

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -822,6 +822,10 @@ void OLEDDisplay::clear(void) {
 }
 
 void OLEDDisplay::drawLogBuffer(uint16_t xMove, uint16_t yMove) {
+  Serial.println("[deprecated] Print functionality now handles buffer management automatically. This is a no-op.");
+}
+
+void OLEDDisplay::drawLogBuffer() {
   uint16_t lineHeight = pgm_read_byte(fontData + HEIGHT_POS);
   // Always align left
   setTextAlignment(TEXT_ALIGN_LEFT);
@@ -842,7 +846,7 @@ void OLEDDisplay::drawLogBuffer(uint16_t xMove, uint16_t yMove) {
     if (this->logBuffer[i] == 10) {
       // Draw string on line `line` from lastPos to length
       // Passing 0 as the lenght because we are in TEXT_ALIGN_LEFT
-      drawStringInternal(xMove, yMove - shiftUp + (line++) * lineHeight, &this->logBuffer[lastPos], length, 0, false);
+      drawStringInternal(0, 0 - shiftUp + (line++) * lineHeight, &this->logBuffer[lastPos], length, 0, false);
       // Remember last pos
       lastPos = i;
       // Reset length
@@ -851,7 +855,7 @@ void OLEDDisplay::drawLogBuffer(uint16_t xMove, uint16_t yMove) {
   }
   // Draw the remaining string
   if (length > 0) {
-    drawStringInternal(xMove, yMove - shiftUp + line * lineHeight, &this->logBuffer[lastPos], length, 0, false);
+    drawStringInternal(0, 0 - shiftUp + line * lineHeight, &this->logBuffer[lastPos], length, 0, false);
   }
 }
 
@@ -868,6 +872,10 @@ void OLEDDisplay::cls() {
   this->logBufferFilled = 0;
   this->logBufferLine = 0;
   display();
+}
+
+bool OLEDDisplay::setLogBuffer(uint16_t lines, uint16_t chars) {
+  Serial.println("[deprecated] Print functionality now handles buffer management automatically. This is a no-op.");
 }
 
 bool OLEDDisplay::setLogBuffer(){
@@ -973,7 +981,7 @@ size_t OLEDDisplay::write(uint8_t c) {
   // Draw to screen unless we're writing a whole string at a time
   if (!this->inhibitDrawLogBuffer) {
     clear();
-    drawLogBuffer(0, 0);
+    drawLogBuffer();
     display();
   }
 
@@ -991,7 +999,7 @@ size_t OLEDDisplay::write(const char* str) {
   }
   this->inhibitDrawLogBuffer = false;
   clear();
-  drawLogBuffer(0, 0);
+  drawLogBuffer();
   display();
   return length;
 }

--- a/src/OLEDDisplay.cpp
+++ b/src/OLEDDisplay.cpp
@@ -876,6 +876,7 @@ void OLEDDisplay::cls() {
 
 bool OLEDDisplay::setLogBuffer(uint16_t lines, uint16_t chars) {
   Serial.println("[deprecated] Print functionality now handles buffer management automatically. This is a no-op.");
+  return true;
 }
 
 bool OLEDDisplay::setLogBuffer(){

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -323,9 +323,8 @@ class OLEDDisplay : public Stream {
     // graphics buffer, which can then be shown on the display with display().
     void cls();
 
-    // (re)creates the logBuffer that printing uses to remember what was on the
-    // screen already 
-    bool setLogBuffer();
+    // Replaced by setLogBuffer() , which is protected
+    bool setLogBuffer(uint16_t lines, uint16_t chars);
 
     // Draw the log buffer at position (x, y)
     //
@@ -398,6 +397,13 @@ class OLEDDisplay : public Stream {
     void inline drawInternal(int16_t xMove, int16_t yMove, int16_t width, int16_t height, const uint8_t *data, uint16_t offset, uint16_t bytesInData) __attribute__((always_inline));
 
     uint16_t drawStringInternal(int16_t xMove, int16_t yMove, const char* text, uint16_t textLength, uint16_t textWidth, bool utf8);
+
+    // (re)creates the logBuffer that printing uses to remember what was on the
+    // screen already 
+    bool setLogBuffer();
+
+    // Draws the contents of the logBuffer to the screen
+    void drawLogBuffer();
 
 	FontTableLookupFunction fontTableLookupFunction;
 };

--- a/src/OLEDDisplay.h
+++ b/src/OLEDDisplay.h
@@ -323,11 +323,9 @@ class OLEDDisplay : public Stream {
     // graphics buffer, which can then be shown on the display with display().
     void cls();
 
-    // This will define the lines and characters you can print to the screen.
-    // When you exeed the buffer size (lines * chars) the output may be
-    // truncated due to the size constraint. (Automatically called with the
-    // correct parameters when you first print to the display.)
-    bool setLogBuffer(uint16_t lines, uint16_t chars);
+    // (re)creates the logBuffer that printing uses to remember what was on the
+    // screen already 
+    bool setLogBuffer();
 
     // Draw the log buffer at position (x, y)
     //


### PR DESCRIPTION
* setLogBuffer needs to be re-called (and past buffer cleared) every time a `setFont` happens, as this changes the number of lines and chars. It now does not take arguments anymore and does things internally and is clearer about when it gives up.
* calculation of shiftUp for when on last line was subtly wrong