### PR TITLE
Implement a different overlay for each page

### DIFF
--- a/src/OLEDDisplayUi.cpp
+++ b/src/OLEDDisplayUi.cpp
@@ -146,7 +146,7 @@ void OLEDDisplayUi::setFrames(FrameCallback* frameFunctions, uint8_t frameCount)
 }
 
 // -/----- Overlays ------\-
-void OLEDDisplayUi::setOverlays(OverlayCallback* overlayFunctions, uint8_t overlayCount){
+void OLEDDisplayUi::setOverlays(OverlayCallback* overlayFunctions, uint8_t* overlayCount){
   this->overlayFunctions = overlayFunctions;
   this->overlayCount     = overlayCount;
 }
@@ -460,9 +460,7 @@ void OLEDDisplayUi::drawIndicator() {
 }
 
 void OLEDDisplayUi::drawOverlays() {
- for (uint8_t i=0;i<this->overlayCount;i++){
-    (this->overlayFunctions[i])(this->display, &this->state);
- }
+  this->overlayFunctions[this->overlayCount[this->state.currentFrame]](this->display, &this->state);
 }
 
 uint8_t OLEDDisplayUi::getNextFrameNumber(){

--- a/src/OLEDDisplayUi.h
+++ b/src/OLEDDisplayUi.h
@@ -141,7 +141,7 @@ class OLEDDisplayUi {
 
     // Values for Overlays
     OverlayCallback*    overlayFunctions;
-    uint8_t             overlayCount;
+    uint8_t*             overlayCount;
 
     // Will the Indicator be drawn
     // 3 Not drawn in both frames
@@ -275,7 +275,7 @@ class OLEDDisplayUi {
     /**
      * Add overlays drawing functions that are draw independent of the Frames
      */
-    void setOverlays(OverlayCallback* overlayFunctions, uint8_t overlayCount);
+    void setOverlays(OverlayCallback *overlayFunctions, uint8_t* overlayCount);
 
 
     // Loading animation


### PR DESCRIPTION
```
FrameCallback frames[] = { drawDateTime, drawCurrentWeather, drawForecast, drawDeviceInfo };
int numberOfFrames = 4;

OverlayCallback dynamicOverlay[] = { drawHeaderOverlay, drawHeaderOverlayTmp }; 
uint8_t overlayIndex[] = { 1, 0, 0, 0 };

ui.setOverlays(dynamicOverlay, overlayIndex); 
```

![4cf833cd9817a95f1562a21f9e2a7ee](https://github.com/user-attachments/assets/25d8a2a0-4504-468e-90a3-579660378f76)

![711b3d4182bd69655293bf6ef5d6fc2](https://github.com/user-attachments/assets/5b848c75-ab8e-4eed-86b5-b78eb9fcbac0)


Configure different bottoms for different pages to achieve better custom display effects